### PR TITLE
Create missing agents on talk instead of erroring

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -41,6 +41,9 @@ STATE_FILE = HOME / "orchestrator_state.json"
 WORKDIR = HOME
 # Skill markdown catalog. Override with AGENTS_ARMY_SKILLS; default is $HOME/SKILLS.
 SKILLS_DIR = Path(os.environ.get("AGENTS_ARMY_SKILLS", HOME / "SKILLS"))
+# The backend an agent gets when none is named: by `spawn`, and by the agent a
+# talk creates for a name that does not exist yet.
+DEFAULT_BACKEND = "claude"
 
 # Named explicitly rather than via __name__: this module runs both as a script
 # (__main__) and as the `orchestrator` console script, and _configure_logging
@@ -127,15 +130,40 @@ class Orchestrator:
             "state: loaded %d agent(s) from %s", len(self.agents), self.state_file
         )
 
-    def spawn(self, name: str, backend: str = "claude") -> Agent:
+    def spawn(self, name: str, backend: str | None = None) -> Agent:
         with self._exclusive():
             self._reload()
             if name in self.agents:
                 raise AgentExistsError(f"agent '{name}' already exists")
-            agent = Agent(name, get_backend(backend))
-            self.agents[name] = agent
-            self._persist()
-            return agent
+            return self._create(name, backend)
+
+    def ensure(self, name: str, backend: str | None = None) -> tuple[Agent, bool]:
+        """Return the named agent, creating it first if it does not exist.
+
+        Reports whether it had to create one, so a caller can say so. The
+        lookup and the create share one lock rather than being a `spawn` after
+        a failed `talk`: two processes naming the same new agent at once then
+        get one agent between them, not a spawn that loses to a duplicate.
+        """
+        with self._exclusive():
+            self._reload()
+            existing = self.agents.get(name)
+            if existing is not None:
+                return existing, False
+            return self._create(name, backend), True
+
+    def _create(self, name: str, backend: str | None) -> Agent:
+        """Register and persist a new agent. The caller holds `_exclusive()`.
+
+        `None` means "whatever the default backend is now": resolving it here
+        rather than in a default argument keeps DEFAULT_BACKEND a live lookup.
+        """
+        agent = Agent(
+            name, get_backend(DEFAULT_BACKEND if backend is None else backend)
+        )
+        self.agents[name] = agent
+        self._persist()
+        return agent
 
     def talk(self, name: str, prompt: str) -> TurnResult:
         with self._agent_lock(name):
@@ -247,6 +275,21 @@ def cmd_spawn(orchestrator: Orchestrator, args: list[str]) -> None:
     print(f"spawned agent '{agent.name}' backend={agent.backend.name}")
 
 
+def _ensure_agent(orchestrator: Orchestrator, name: str) -> None:
+    """Create `name` if talking to it would otherwise fail, and say so.
+
+    The notice goes to stderr: stdout carries the reply and is what a pipe
+    reads, and an agent having been created is commentary on the turn, not
+    part of it.
+    """
+    agent, created = orchestrator.ensure(name)
+    if created:
+        print(
+            f"spawned agent '{agent.name}' backend={agent.backend.name}",
+            file=sys.stderr,
+        )
+
+
 def cmd_talk(orchestrator: Orchestrator, args: list[str]) -> None:
     parser = argparse.ArgumentParser(prog="talk")
     parser.add_argument("name")
@@ -258,6 +301,7 @@ def cmd_talk(orchestrator: Orchestrator, args: list[str]) -> None:
         # `set -e` must not read "nothing ran" as a turn that succeeded.
         print("usage: talk <agent> <prompt>", file=sys.stderr)
         raise SystemExit(2)
+    _ensure_agent(orchestrator, opts.name)
     try:
         result = orchestrator.talk(opts.name, prompt)
     except (ClaudeTurnError, CodexTurnError) as exc:
@@ -317,11 +361,11 @@ def cmd_invoke_skills(orchestrator: Orchestrator, args: list[str]) -> None:
         opts.agent,
         ", ".join(name for name, _path in resolved),
     )
+    # After the skills resolve, so a bad --skill exits without having left a
+    # new agent behind for a turn that never ran.
+    _ensure_agent(orchestrator, opts.agent)
     try:
         result = orchestrator.talk(opts.agent, composed)
-    except KeyError:
-        print(f"no agent named '{opts.agent}'", file=sys.stderr)
-        raise SystemExit(1) from None
     except (ClaudeTurnError, CodexTurnError) as exc:
         print(str(exc), file=sys.stderr)
         raise SystemExit(1) from None

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -657,6 +657,45 @@ class TestOrchestrator:
         with pytest.raises(ValueError, match="already exists"):
             orch.spawn("a1", "claude")
 
+    def test_ensure_creates_a_missing_agent(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "s.json"
+        orch = Orchestrator(state_file=state_file)
+        agent, created = orch.ensure("fresh", "echo")
+        assert created is True
+        assert agent.name == "fresh"
+        assert agent.backend.name == "echo"
+        assert Orchestrator(state_file=state_file).list_agents() == ["fresh"]
+
+    def test_ensure_defaults_to_the_default_backend(self, tmp_path: Path) -> None:
+        orch = Orchestrator(state_file=tmp_path / "s.json")
+        agent, _created = orch.ensure("fresh")
+        assert agent.backend.name == orchestrator.DEFAULT_BACKEND
+
+    def test_ensure_returns_an_existing_agent_untouched(self, tmp_path: Path) -> None:
+        """An existing agent keeps its backend and its session, not a new one."""
+        state_file = tmp_path / "s.json"
+        orch = Orchestrator(state_file=state_file)
+        orch.spawn("a", "echo")
+        orch.talk("a", "hi")
+        agent, created = orch.ensure("a", "codex")
+        assert created is False
+        assert agent.backend.name == "echo"
+        assert agent.session_id == "echo-sid"
+
+    def test_ensure_takes_an_exclusive_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The lookup and the create are one critical section, not two."""
+        seen: list[int] = []
+
+        def fake_flock(_fd: int, op: int) -> None:
+            seen.append(op)
+
+        monkeypatch.setattr(fcntl, "flock", fake_flock)
+        Orchestrator(state_file=tmp_path / "s.json").ensure("a", "echo")
+        assert fcntl.LOCK_EX in seen
+        assert fcntl.LOCK_UN in seen
+
     def test_talk_unknown_raises(self, tmp_path: Path) -> None:
         orch = Orchestrator(state_file=tmp_path / "s.json")
         with pytest.raises(KeyError, match="no agent named"):
@@ -911,6 +950,40 @@ class TestCLI:
         assert "session=echo-sid" in out
         assert "echo:hello there" in out
 
+    def test_cmd_talk_creates_a_missing_agent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Talking to a name that does not exist spawns it and runs the turn."""
+        monkeypatch.setattr(orchestrator, "DEFAULT_BACKEND", "echo")
+        state_file = tmp_path / "s.json"
+        orch = Orchestrator(state_file=state_file)
+        cmd_talk(orch, ["fresh", "hello"])
+        captured = capsys.readouterr()
+        assert captured.err == "spawned agent 'fresh' backend=echo\n"
+        assert "echo:hello" in captured.out
+        assert Orchestrator(state_file=state_file).list_agents() == ["fresh"]
+
+    def test_cmd_talk_says_nothing_extra_for_an_existing_agent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        orch = Orchestrator(state_file=tmp_path / "s.json")
+        orch.spawn("a", "echo")
+        cmd_talk(orch, ["a", "hello"])
+        assert capsys.readouterr().err == ""
+
+    def test_cmd_talk_empty_prompt_creates_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A rejected invocation must not leave an agent behind."""
+        state_file = tmp_path / "s.json"
+        orch = Orchestrator(state_file=state_file)
+        with pytest.raises(SystemExit, match="2"):
+            cmd_talk(orch, ["fresh", "   "])
+        assert Orchestrator(state_file=state_file).list_agents() == []
+
     def test_cmd_talk_empty_prompt_exits_nonzero(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -1078,19 +1151,19 @@ class TestCLI:
         main(["spawn", "a", "-b", "echo"])
         assert "spawned agent 'a' backend=echo" in capsys.readouterr().out
 
-    def test_main_unknown_agent_is_one_line(
+    def test_main_talk_creates_a_missing_agent(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
+        """`talk <new-name>` is a spawn plus a turn, not an error."""
         monkeypatch.setattr(orchestrator, "STATE_FILE", tmp_path / "s.json")
-        with pytest.raises(SystemExit, match="1"):
-            main(["talk", "nope", "hi"])
+        monkeypatch.setattr(orchestrator, "DEFAULT_BACKEND", "echo")
+        main(["talk", "nope", "hi"])
         captured = capsys.readouterr()
-        assert captured.err == "no agent named 'nope'\n"
-        assert captured.out == ""
-        assert "Traceback" not in captured.err
+        assert captured.err == "spawned agent 'nope' backend=echo\n"
+        assert "echo:hi" in captured.out
 
     def test_main_duplicate_spawn_is_one_line(
         self,

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -424,6 +424,15 @@ class TestCmdInvokeSkills:
         assert "unknown skill 'nope'" in captured.err
         assert captured.out == ""
 
+    def test_unknown_skill_creates_no_agent(
+        self, orch: Orchestrator, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit, match="1"):
+            cmd_invoke_skills(
+                orch, ["--agent", "missing", "--skill", "nope", "--prompt", "x"]
+            )
+        assert orch.list_agents() == ["a"]
+
     def test_conflict_exits_without_talking(
         self,
         orch: Orchestrator,
@@ -440,17 +449,18 @@ class TestCmdInvokeSkills:
             assert str(path) in captured.err
         assert captured.out == ""
 
-    def test_unknown_agent_exits_without_a_traceback(
-        self, orch: Orchestrator, capsys: pytest.CaptureFixture[str]
+    def test_unknown_agent_is_created_then_talked_to(
+        self, orch: Orchestrator, monkeypatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        with pytest.raises(SystemExit, match="1"):
-            cmd_invoke_skills(
-                orch,
-                ["--agent", "missing", "--skill", "foo", "--prompt", "x"],
-            )
+        monkeypatch.setattr(orchestrator, "DEFAULT_BACKEND", "echo")
+        cmd_invoke_skills(
+            orch,
+            ["--agent", "missing", "--skill", "foo", "--prompt", "x"],
+        )
         captured = capsys.readouterr()
-        assert captured.err == "no agent named 'missing'\n"
-        assert captured.out == ""
+        assert captured.err == "spawned agent 'missing' backend=echo\n"
+        assert "session=echo-sid" in captured.out
+        assert orch.list_agents() == ["a", "missing"]
 
     def test_empty_prompt_exits_nonzero_like_talk(
         self, orch: Orchestrator, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## What

Talking to a name that is not in the registry now spawns it with the default backend and runs the turn. The same happens for `--skill`. A spawn notice goes to stderr so a pipe still sees only the reply.

`ensure()` does the lookup and the create under one exclusive lock, so two processes naming the same new agent get one agent, not a duplicate. An empty prompt or an unknown skill still exits before anything is created.

The `Orchestrator.talk` API still raises `AgentNotFoundError` for a missing name; only the CLI auto-creates.

## Gates (local)

215 tests · 100% coverage · mutation 98.2% (915/932, floor 98.0%) · ratchet, integrity, ruff, types · Semgrep, Bandit, pip-audit, Gitleaks clean.

## How to review

```sh
uv run orchestrator talk fresh "hello"
# stderr: spawned agent 'fresh' backend=claude
# stdout: the reply
```