### PR TITLE
Make --skill optional on the CLI skill invocation

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -340,28 +340,30 @@ def cmd_delete(orchestrator: Orchestrator, args: list[str]) -> None:
 def cmd_invoke_skills(orchestrator: Orchestrator, args: list[str]) -> None:
     parser = argparse.ArgumentParser(prog="orchestrator")
     parser.add_argument("--agent", required=True)
-    parser.add_argument("--skill", required=True)
+    parser.add_argument("--skill")
     parser.add_argument("--prompt", required=True)
     opts = parser.parse_args(args)
     prompt = opts.prompt.strip()
     if not prompt:
         print(
-            "usage: orchestrator --agent NAME --skill NAME[,NAME...] --prompt TEXT",
+            "usage: orchestrator --agent NAME [--skill NAME[,NAME...]] --prompt TEXT",
             file=sys.stderr,
         )
         raise SystemExit(2)
-    try:
-        names = parse_skill_names(opts.skill)
-        resolved = resolve_skills(names, SKILLS_DIR)
-    except SkillError as exc:
-        print(str(exc), file=sys.stderr)
-        raise SystemExit(1) from None
-    composed = compose_skill_prompt(resolved, prompt)
-    log.info(
-        "agent '%s': attaching skill(s) %s",
-        opts.agent,
-        ", ".join(name for name, _path in resolved),
-    )
+    composed = prompt
+    if opts.skill is not None:
+        try:
+            names = parse_skill_names(opts.skill)
+            resolved = resolve_skills(names, SKILLS_DIR)
+        except SkillError as exc:
+            print(str(exc), file=sys.stderr)
+            raise SystemExit(1) from None
+        composed = compose_skill_prompt(resolved, prompt)
+        log.info(
+            "agent '%s': attaching skill(s) %s",
+            opts.agent,
+            ", ".join(name for name, _path in resolved),
+        )
     # After the skills resolve, so a bad --skill exits without having left a
     # new agent behind for a turn that never ran.
     _ensure_agent(orchestrator, opts.agent)
@@ -416,7 +418,7 @@ OWN_LOGGERS = ("orchestrator", "backends")
 
 USAGE = (
     "usage: orchestrator [-v|-vv] <command> [args...]\n"
-    "       orchestrator [-v|-vv] --agent NAME --skill NAME[,NAME...] --prompt TEXT\n"
+    "       orchestrator [-v|-vv] --agent NAME [--skill NAME[,NAME...]] --prompt TEXT\n"
     "       orchestrator [-v|-vv] --list {agents,skills}\n"
     "  -h, --help      show this message\n"
     "  -v, --verbose   log each step and how long it took\n"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1664,7 +1664,7 @@ class TestCLI:
         captured = capsys.readouterr()
         assert captured.err == (
             "usage: orchestrator [-v|-vv] <command> [args...]\n"
-            "       orchestrator [-v|-vv] --agent NAME --skill NAME[,NAME...] "
+            "       orchestrator [-v|-vv] --agent NAME [--skill NAME[,NAME...]] "
             "--prompt TEXT\n"
             "       orchestrator [-v|-vv] --list {agents,skills}\n"
             "  -h, --help      show this message\n"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -471,7 +471,7 @@ class TestCmdInvokeSkills:
             )
         captured = capsys.readouterr()
         assert captured.err == (
-            "usage: orchestrator --agent NAME --skill NAME[,NAME...] --prompt TEXT\n"
+            "usage: orchestrator --agent NAME [--skill NAME[,NAME...]] --prompt TEXT\n"
         )
         assert captured.out == ""
 
@@ -493,14 +493,14 @@ class TestCmdInvokeSkills:
         assert "usage: orchestrator" in err
         assert "--agent" in err
 
-    def test_missing_skill_flag_is_argparse_exit_2(
+    def test_missing_skill_flag_talks_without_attaching_any_skill(
         self, orch: Orchestrator, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        with pytest.raises(SystemExit, match="2"):
-            cmd_invoke_skills(orch, ["--agent", "a", "--prompt", "x"])
-        err = capsys.readouterr().err
-        assert "usage: orchestrator" in err
-        assert "--skill" in err
+        cmd_invoke_skills(orch, ["--agent", "a", "--prompt", "x"])
+        out = capsys.readouterr().out
+        assert "session=echo-sid" in out
+        assert out.strip().endswith("x")
+        assert "- foo:" not in out
 
     def test_duplicate_skill_flag_value_exits(
         self, orch: Orchestrator, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary
- `--skill` on `orchestrator --agent ... --skill ... --prompt ...` is no longer a required flag
- When omitted, the raw prompt is sent to the agent with no skill attached (no header, no "attaching skill(s)" log line)
- Updated usage strings and tests to match

## Test plan
- [x] `uv run pytest -q` (272 passed)