### PR TITLE
Move post-spec workflow bot comments onto the PR

### DIFF
--- a/examples/gabriels_workflow/README.md
+++ b/examples/gabriels_workflow/README.md
@@ -5,11 +5,12 @@ main flow:
 
 1. Load the issue.
 2. Clarify the request with an expander and an independent griller.
-3. Produce a specification.
-4. Implement it.
-5. Run CI and repair failures.
-6. Obtain specification and quality approvals.
-7. Commit, push, and create a draft pull request.
+3. Produce a specification — the last bot comment on the issue.
+4. Open a draft pull request. Implementation, CI, and review talk there.
+5. Implement the specification.
+6. Run CI and repair failures.
+7. Obtain specification and quality approvals.
+8. Commit, push, and update the pull request.
 
 The supporting modules own the details:
 
@@ -61,15 +62,17 @@ values are passed through to the configured CLI. Each of `expander`, `griller`,
 `specifier`, `implementer`, `reviewer-specification`, and `reviewer-quality`
 must be configured explicitly.
 
-Each stage result is commented through that stage role's GitHub App. The
-implementer app also loads the issue, posts workflow-level status, and creates
-the pull request.
+Each stage result is commented through that stage role's GitHub App. Expansion,
+grilling, and the specification stay on the issue — the specification is the
+last bot comment there. The implementer app then opens a draft pull request and
+posts implementation, CI, and review there. The same app commits, pushes, and
+updates that pull request when the work is done.
 
 CI is reported as a checklist rather than a log: one ✅, ❌ or ⚪ per gate that
 `make ci` runs, a failing gate carrying a one-line reason. The gate list comes
 from `make ci-gates`, and a gate that never started when an earlier one failed
 is marked as such instead of being reported as passing. The full CI output
-stays out of the issue — it is checkpointed under `.git/gdw/` and handed to
+stays out of GitHub — it is checkpointed under `.git/gdw/` and handed to
 the repair agent, which is what actually reads it.
 
 Install all six apps on the configured repository with the

--- a/examples/gabriels_workflow/development_workflow.py
+++ b/examples/gabriels_workflow/development_workflow.py
@@ -72,6 +72,9 @@ AGENT_ROLES = frozenset(
         "reviewer-quality",
     }
 )
+# Clarification and the specification stay on the issue. Once that
+# specification is posted, every later bot comment belongs on the PR.
+ISSUE_COMMENT_ROLES = frozenset({"expander", "griller", "specifier"})
 
 
 def configure_logging(verbose: bool = False) -> None:
@@ -156,6 +159,8 @@ class GitHubService(Protocol):
         self, number: int, key: str, title: str, payload: object
     ) -> None: ...
 
+    def collect_markers(self, number: int) -> None: ...
+
     def create_pr(
         self,
         *,
@@ -166,9 +171,13 @@ class GitHubService(Protocol):
         draft: bool,
     ) -> str: ...
 
+    def update_pr(self, number: int, *, body: str) -> None: ...
+
 
 class RepositoryService(Protocol):
     def run_ci(self) -> CommandResult: ...
+
+    def ensure_branch_ahead(self, message: str, base_sha: str) -> None: ...
 
     def commit(self, message: str, base_sha: str) -> None: ...
 
@@ -428,6 +437,27 @@ def _render_comment(marker: str, title: str, payload: object) -> str:
     return f"{marker}\n## GDW — {title}\n\n{_markdown(payload)}\n"
 
 
+def _pull_request_number(url: str) -> int:
+    match = re.search(r"/(\d+)/?$", url.strip())
+    if match is None:
+        raise WorkflowError(
+            f"GitHub returned a pull-request URL without a number: {url!r}"
+        )
+    return int(match.group(1))
+
+
+def _comment_markers(comments: object) -> set[str]:
+    if not isinstance(comments, list):
+        return set()
+    return {
+        line
+        for comment in comments
+        if isinstance(comment, dict)
+        for line in str(comment.get("body", "")).splitlines()
+        if line.startswith("<!-- gdw:")
+    }
+
+
 class ArtifactStore:
     """Durable, atomic checkpoints kept under .git so they are never committed."""
 
@@ -460,7 +490,14 @@ class ArtifactStore:
         )
         self._write(
             self.metadata_path,
-            {"issue": issue, "branch": branch, "base_sha": base_sha, "pr_url": None},
+            {
+                "issue": issue,
+                "branch": branch,
+                "base_sha": base_sha,
+                "pr_url": None,
+                "pr_number": None,
+                "development_pr_url": None,
+            },
         )
 
     @property
@@ -481,6 +518,12 @@ class ArtifactStore:
     def record_pr(self, url: str) -> None:
         metadata = self.metadata
         metadata["pr_url"] = url
+        self._write(self.metadata_path, metadata)
+
+    def record_development_pr(self, number: int, url: str) -> None:
+        metadata = self.metadata
+        metadata["pr_number"] = number
+        metadata["development_pr_url"] = url
         self._write(self.metadata_path, metadata)
 
     def artifact_path(self, name: str) -> Path:
@@ -594,6 +637,21 @@ class GitRepository:
         )
         return CommandResult(proc.returncode, _bounded(evidence), gates)
 
+    def ensure_branch_ahead(self, message: str, base_sha: str) -> None:
+        """Make the branch pushable as a pull request, without implementation.
+
+        GitHub refuses a PR whose head matches the base. An empty commit is
+        enough to open the draft that later bot comments belong on; the
+        implementation commit still happens in publish().
+        """
+
+        commits = self._call("rev-list", "--count", f"{base_sha}..HEAD").strip()
+        if commits != "0":
+            LOGGER.info("git: already %s commit(s) ahead of %s", commits, base_sha)
+            return
+        LOGGER.info("git: creating empty start-work commit ahead of %s", base_sha)
+        self._call("commit", "--allow-empty", "-m", message)
+
     def commit(self, message: str, base_sha: str) -> None:
         tracked = self._call("diff", "--no-renames", "--name-only", "-z", "HEAD").split(
             "\0"
@@ -676,21 +734,19 @@ class GitHub:
         )
         comments = payload.get("comments", [])
         if isinstance(comments, list):
-            self.markers = {
-                line
-                for comment in comments
-                if isinstance(comment, dict)
-                for line in str(comment.get("body", "")).splitlines()
-                if line.startswith("<!-- gdw:")
-            }
+            self.markers = _comment_markers(comments)
         return payload
+
+    def collect_markers(self, number: int) -> None:
+        payload = self._json_call("issue", "view", str(number), "--json", "comments")
+        self.markers |= _comment_markers(payload.get("comments", []))
 
     def comment_once(self, number: int, key: str, title: str, payload: object) -> None:
         marker = f"<!-- gdw:{number}:{key} -->"
         if marker in self.markers:
             LOGGER.info("github: comment '%s' already posted, skipping", key)
             return
-        LOGGER.info("github: commenting '%s' on issue #%s", key, number)
+        LOGGER.info("github: commenting '%s' on #%s", key, number)
         self._body_call(
             _render_comment(marker, title, payload),
             "issue",
@@ -719,6 +775,10 @@ class GitHub:
         if draft:
             args.append("--draft")
         return self._body_call(body, *args, "--body-file").strip()
+
+    def update_pr(self, number: int, *, body: str) -> None:
+        LOGGER.info("github: updating pull request #%s", number)
+        self._body_call(body, "pr", "edit", str(number), "--body-file")
 
     def _repo_args(self) -> list[str]:
         return [] if self.repository is None else ["--repo", self.repository]
@@ -947,6 +1007,7 @@ class DevelopmentWorkflow:
         issue_context = self.load_issue()
         expansion = self.clarify(issue_context)
         specification = self.specify(issue_context, expansion)
+        self.open_pull_request(specification)
         self.implement(specification)
         ci_summary = self.stabilize(specification)
         final_reviews = self.review(specification, ci_summary)
@@ -969,9 +1030,12 @@ class DevelopmentWorkflow:
             and isinstance(comment.get("body"), str)
             and "<!-- gdw:" not in comment["body"]
         ][-5:]
-        # Only this client read the issue, so only it knows which stages have
-        # already been commented. Every other role posts through its own app
-        # and would repeat them all on a resumed run.
+        pr_number = self.store.metadata.get("pr_number")
+        if isinstance(pr_number, int) and pr_number > 0:
+            self.github.collect_markers(pr_number)
+        # Only this client read the issue (and PR), so only it knows which
+        # stages have already been commented. Every other role posts through
+        # its own app and would repeat them all on a resumed run.
         for client in self.role_github.values():
             if client is not self.github:
                 client.adopt_markers(self.github.markers)
@@ -1011,6 +1075,7 @@ class DevelopmentWorkflow:
         )
 
     def implement(self, specification: dict) -> dict:
+        self.open_pull_request(specification)
         implementation = self._stage(
             Stage(
                 "implementation",
@@ -1025,36 +1090,62 @@ class DevelopmentWorkflow:
         return implementation
 
     def stabilize(self, specification: dict) -> dict:
+        self.open_pull_request(specification)
         return self._ci_until_green("implementation", specification)
 
     def review(self, specification: dict, ci_summary: dict) -> dict[str, dict]:
+        self.open_pull_request(specification)
         return self._review_until_approved(specification, ci_summary)
 
+    def open_pull_request(self, specification: dict) -> str:
+        """Open the draft PR that later bot comments belong on.
+
+        The specification comment is the last thing this workflow posts on the
+        issue. Implementation, CI, and review talk on the pull request.
+        """
+
+        existing_number = self.store.metadata.get("pr_number")
+        existing_url = self.store.metadata.get("development_pr_url")
+        if (
+            isinstance(existing_number, int)
+            and existing_number > 0
+            and isinstance(existing_url, str)
+            and existing_url
+        ):
+            LOGGER.info("workflow: reusing development pull request %s", existing_url)
+            return existing_url
+        title = str(specification["title"]).replace("\n", " ")[:72]
+        self.repository.ensure_branch_ahead(
+            f"Start work on #{self.issue_number}: {title}",
+            str(self.store.metadata["base_sha"]),
+        )
+        self.repository.push(self.branch)
+        url = self.github.create_pr(
+            base=self.base_branch,
+            branch=self.branch,
+            title=title,
+            body=self._opening_pr_body(specification),
+            draft=self.draft,
+        )
+        if not url:
+            raise WorkflowError("GitHub returned an empty pull-request URL")
+        number = _pull_request_number(url)
+        LOGGER.info("workflow: pull request created at %s", url)
+        self.store.record_development_pr(number, url)
+        return url
+
     def publish(self, specification: dict, final_reviews: dict[str, dict]) -> str:
+        url = self.open_pull_request(specification)
+        number = _pull_request_number(url)
         base_sha = str(self.store.metadata["base_sha"])
         commit_title = str(specification["title"]).replace("\n", " ")[:72]
         self.repository.commit(
             f"Implement #{self.issue_number}: {commit_title}", base_sha
         )
         self.repository.push(self.branch)
-        body = self._pr_body(specification, final_reviews)
-        url = self.github.create_pr(
-            base=self.base_branch,
-            branch=self.branch,
-            title=commit_title,
-            body=body,
-            draft=self.draft,
-        )
-        if not url:
-            raise WorkflowError("GitHub returned an empty pull-request URL")
-        LOGGER.info("workflow: pull request created at %s", url)
+        self.github.update_pr(number, body=self._pr_body(specification, final_reviews))
+        LOGGER.info("workflow: pull request updated at %s", url)
         self.store.record_pr(url)
-        self.github.comment_once(
-            self.issue_number,
-            "pull-request",
-            "Pull request created",
-            {"url": url, "draft": self.draft},
-        )
         return url
 
     def _reach_agreement(self, issue_context: dict) -> dict:
@@ -1131,9 +1222,9 @@ class DevelopmentWorkflow:
             result = ci.as_json()
             self.store.save(key, result)
             # The log itself stays local: it is checkpointed and handed to the
-            # repair agent, while the issue gets the verdict it can act on.
+            # repair agent, while the pull request gets the verdict it can act on.
             self.github.comment_once(
-                self.issue_number,
+                self._comment_number(),
                 key,
                 f"CI checks for {prefix}, attempt {attempt}",
                 ci.checklist(),
@@ -1258,7 +1349,9 @@ class DevelopmentWorkflow:
         LOGGER.debug("stage %s: reply\n%s", stage.key, _json(result))
         self.store.save(stage.key, result)
         role_github = self.role_github.get(stage.role, self.github)
-        role_github.comment_once(self.issue_number, stage.key, stage.title, result)
+        role_github.comment_once(
+            self._comment_number(stage.role), stage.key, stage.title, result
+        )
         return result
 
     def _require_complete(self, result: dict, stage: str, key: str) -> None:
@@ -1280,6 +1373,23 @@ class DevelopmentWorkflow:
         LOGGER.debug("%s: unresolved state\n%s", process, unresolved)
         if unresolved == previous_unresolved:
             raise WorkflowStopped(f"{process} stalled with the same unresolved state")
+
+    def _comment_number(self, role: str | None = None) -> int:
+        if role in ISSUE_COMMENT_ROLES:
+            return self.issue_number
+        number = self.store.metadata.get("pr_number")
+        if isinstance(number, int) and number > 0:
+            return number
+        return self.issue_number
+
+    def _opening_pr_body(self, specification: dict) -> str:
+        return (
+            f"Closes #{self.issue_number}\n\n"
+            "## Validated specification\n\n"
+            f"{_markdown(specification)}\n\n"
+            "Generated by Gabriel's development workflow. Implementation, CI, "
+            "and review comments follow on this pull request.\n"
+        )
 
     def _pr_body(self, specification: dict, reviews: dict[str, dict]) -> str:
         return (

--- a/examples/gabriels_workflow/github_app_client.py
+++ b/examples/gabriels_workflow/github_app_client.py
@@ -87,6 +87,17 @@ class GitHubAppClient:
         """
         self.markers |= markers
 
+    def collect_markers(self, number: int) -> None:
+        """Union gdw markers from comments on this issue or pull request."""
+
+        issue = self.repository.get_issue(number)
+        self.markers |= {
+            line
+            for comment in issue.get_comments()
+            for line in (comment.body or "").splitlines()
+            if line.startswith("<!-- gdw:")
+        }
+
     def comment(self, number: int, body: str) -> None:
         self.repository.get_issue(number).create_comment(body)
 
@@ -103,7 +114,7 @@ class GitHubAppClient:
             return
         from examples.gabriels_workflow.development_workflow import _render_comment
 
-        LOGGER.info("github-app: commenting '%s' on issue #%s", key, number)
+        LOGGER.info("github-app: commenting '%s' on #%s", key, number)
         self.comment(number, _render_comment(marker, title, payload))
         self.markers.add(marker)
 
@@ -130,6 +141,10 @@ class GitHubAppClient:
             draft=draft,
         )
         return pull_request.html_url
+
+    def update_pr(self, number: int, *, body: str) -> None:
+        LOGGER.info("github-app: updating pull request #%s", number)
+        self.repository.get_pull(number).edit(body=body)
 
     def close(self) -> None:
         if self.github is not None:

--- a/examples/gabriels_workflow/simple_development_workflow.py
+++ b/examples/gabriels_workflow/simple_development_workflow.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Turn one GitHub issue into a reviewed draft pull request."""
+"""Turn one GitHub issue into a reviewed draft pull request.
+
+The issue conversation ends at the specification. After that, bot comments
+belong on the pull request the implementer opens.
+"""
 
 import argparse
 import sys
@@ -50,6 +54,7 @@ def main(argv: list[str] | None = None) -> int:
             issue = workflow.load_issue()
             proposal = workflow.clarify(issue)
             specification = workflow.specify(issue, proposal)
+            workflow.open_pull_request(specification)
             workflow.implement(specification)
             passing_ci = workflow.stabilize(specification)
             approvals = workflow.review(specification, passing_ci)

--- a/tests/test_development_workflow.py
+++ b/tests/test_development_workflow.py
@@ -369,6 +369,8 @@ class FakeGitHub:
     def __init__(self, pr_url: str = "https://example.test/pr/1") -> None:
         self.comments: list[tuple] = []
         self.pr_calls: list[dict] = []
+        self.pr_updates: list[dict] = []
+        self.collected_markers: list[int] = []
         self.pr_url = pr_url
         self.markers: set[str] = set()
 
@@ -377,6 +379,9 @@ class FakeGitHub:
 
     def adopt_markers(self, markers: set[str]) -> None:
         self.markers |= markers
+
+    def collect_markers(self, number: int) -> None:
+        self.collected_markers.append(number)
 
     def comment_once(self, number: int, key: str, title: str, payload: object) -> None:
         if key in self.markers:
@@ -404,21 +409,69 @@ class FakeGitHub:
         )
         return self.pr_url
 
+    def update_pr(self, number: int, *, body: str) -> None:
+        self.pr_updates.append({"number": number, "body": body})
+
 
 class FakeRepository:
     def __init__(self, ci: list[gdw.CommandResult] | None = None) -> None:
         self.ci = deque(ci or [gdw.CommandResult(0, "green")])
         self.commits: list[tuple[str, str]] = []
+        self.start_commits: list[tuple[str, str]] = []
         self.pushes: list[str] = []
 
     def run_ci(self) -> gdw.CommandResult:
         return self.ci.popleft()
+
+    def ensure_branch_ahead(self, message: str, base_sha: str) -> None:
+        self.start_commits.append((message, base_sha))
 
     def commit(self, message: str, base_sha: str) -> None:
         self.commits.append((message, base_sha))
 
     def push(self, branch: str) -> None:
         self.pushes.append(branch)
+
+
+class EntryWorkflow:
+    def __init__(self, completed: str | None) -> None:
+        self.completed = completed
+        self.calls: list[object] = []
+
+    def completed_url(self) -> str | None:
+        self.calls.append("completed")
+        return self.completed
+
+    def load_issue(self) -> dict:
+        self.calls.append("load")
+        return {"issue": 1}
+
+    def clarify(self, issue: dict) -> dict:
+        self.calls.append(("clarify", issue))
+        return {"proposal": 1}
+
+    def specify(self, issue: dict, proposal: dict) -> dict:
+        self.calls.append(("specify", issue, proposal))
+        return {"specification": 1}
+
+    def open_pull_request(self, specification: dict) -> str:
+        self.calls.append(("open_pull_request", specification))
+        return "https://example.test/pulls/new"
+
+    def implement(self, specification: dict) -> None:
+        self.calls.append(("implement", specification))
+
+    def stabilize(self, specification: dict) -> dict:
+        self.calls.append(("stabilize", specification))
+        return {"ci": "green"}
+
+    def review(self, specification: dict, ci: dict) -> dict:
+        self.calls.append(("review", specification, ci))
+        return {"reviews": "approved"}
+
+    def publish(self, specification: dict, reviews: dict) -> str:
+        self.calls.append(("publish", specification, reviews))
+        return "https://example.test/pulls/new"
 
 
 class FakeAgents:
@@ -498,6 +551,10 @@ def test_helpers_render_and_bound() -> None:
     assert rendered.count("_None._") == 2
     assert "```json" not in rendered
     assert '{"' not in rendered
+    assert gdw._pull_request_number("https://github.com/owner/repo/pull/12") == 12
+    assert gdw._pull_request_number("https://example.test/pr/1/") == 1
+    with pytest.raises(gdw.WorkflowError, match="without a number"):
+        gdw._pull_request_number("https://example.test/pulls")
     assert gdw.CommandResult(0, "ok").succeeded is True
     assert gdw.CommandResult(1, "bad").succeeded is False
     assert gdw.CommandResult(1, "bad").as_json() == {
@@ -519,6 +576,10 @@ def test_artifact_store_round_trip_resume_and_errors(tmp_path: Path) -> None:
     store.save("stage", {"answer": 1})
     assert store.has("stage") is True
     assert store.load("stage") == {"answer": 1}
+    store.record_development_pr(12, "https://example.test/pr/12")
+    assert store.metadata["pr_number"] == 12
+    assert store.metadata["development_pr_url"] == "https://example.test/pr/12"
+    assert store.metadata["pr_url"] is None
     store.record_pr("https://example.test/pr")
     assert store.metadata["pr_url"] == "https://example.test/pr"
     store.initialize(7, "feature", "ignored-on-resume")
@@ -608,6 +669,23 @@ def test_git_repository_prepare_ci_commit_push_and_failures(tmp_path: Path) -> N
         no_commits.commit("message", "abc")
 
 
+def test_git_repository_opens_an_empty_commit_only_when_the_branch_matches_base(
+    tmp_path: Path,
+) -> None:
+    ahead = ScriptedRun([_completed([], stdout="2\n")])
+    gdw.GitRepository(tmp_path, ahead).ensure_branch_ahead("Start work", "abc")
+    empty = ScriptedRun([_completed([], stdout="0\n"), _completed([])])
+    gdw.GitRepository(tmp_path, empty).ensure_branch_ahead("Start work", "abc")
+
+    assert [call[0] for call in ahead.calls] == [
+        ["git", "rev-list", "--count", "abc..HEAD"],
+    ]
+    assert [call[0] for call in empty.calls] == [
+        ["git", "rev-list", "--count", "abc..HEAD"],
+        ["git", "commit", "--allow-empty", "-m", "Start work"],
+    ]
+
+
 def test_github_owns_markdown_comments_and_pull_requests(tmp_path: Path) -> None:
     bodies: list[str] = []
 
@@ -657,6 +735,8 @@ def test_github_owns_markdown_comments_and_pull_requests(tmp_path: Path) -> None
         == "https://example.test/pr/9"
     )
     assert bodies[-1] == "PR body"
+    github.update_pr(9, body="Updated body")
+    assert bodies[-1] == "Updated body"
 
     nondraft_bodies: list[str] = []
 
@@ -696,6 +776,40 @@ def test_github_reports_missing_invalid_and_failed_cli(
         run=ScriptedRun([_completed([], stdout='{"comments": {}}')]),
     )
     assert odd_comments.issue(1) == {"comments": {}}
+    odd_markers = gdw.GitHub(
+        tmp_path,
+        executable=Path("/gh"),
+        run=ScriptedRun([_completed([], stdout='{"comments": {}}')]),
+    )
+    odd_markers.markers = {"keep"}
+    odd_markers.collect_markers(8)
+    assert odd_markers.markers == {"keep"}
+    pr_markers = gdw.GitHub(
+        tmp_path,
+        executable=Path("/gh"),
+        run=ScriptedRun(
+            [
+                _completed(
+                    [],
+                    stdout=json.dumps(
+                        {
+                            "comments": [
+                                {"body": "<!-- gdw:1:implementation -->\nimpl"},
+                                "noise",
+                                {"body": 12},
+                            ]
+                        }
+                    ),
+                )
+            ]
+        ),
+    )
+    pr_markers.markers = {"<!-- gdw:42:specification -->"}
+    pr_markers.collect_markers(1)
+    assert pr_markers.markers == {
+        "<!-- gdw:42:specification -->",
+        "<!-- gdw:1:implementation -->",
+    }
     invalid_json = gdw.GitHub(
         tmp_path,
         executable=Path("/gh"),
@@ -810,6 +924,28 @@ def test_github_app_client_owns_app_auth_comments_and_pull_requests(
     integration.get_repo_installation.assert_called_once_with("owner", "repo")
     app_auth.get_installation_auth.assert_called_once_with(77)
     github_factory.assert_called_once_with(auth="installation-auth", per_page=100)
+
+
+def test_github_app_client_collects_pr_markers_and_updates_the_body() -> None:
+    issue = SimpleNamespace(
+        get_comments=lambda: [
+            SimpleNamespace(body="<!-- gdw:1:implementation -->\nalready on the PR"),
+            SimpleNamespace(body=None),
+        ]
+    )
+    pull = SimpleNamespace(edit=MagicMock())
+    repository = SimpleNamespace(
+        get_issue=MagicMock(return_value=issue),
+        get_pull=MagicMock(return_value=pull),
+    )
+    client = app_github.GitHubAppClient(cast(app_github.Repository, repository))
+
+    client.collect_markers(1)
+    client.update_pr(9, body="Updated")
+
+    assert "<!-- gdw:1:implementation -->" in client.markers
+    repository.get_pull.assert_called_once_with(9)
+    pull.edit.assert_called_once_with(body="Updated")
 
 
 def test_agent_gateway_validates_prompt_and_removes_github_access(
@@ -1109,12 +1245,20 @@ def test_workflow_happy_path_and_completed_resume(tmp_path: Path) -> None:
     ]
     workflow, github, repository, agents = _workflow(tmp_path, replies)
     assert workflow.run() == "https://example.test/pr/1"
+    assert repository.start_commits == [
+        ("Start work on #42: Implement the thing with detail", "base-sha")
+    ]
     assert repository.commits == [
         ("Implement #42: Implement the thing with detail", "base-sha")
     ]
-    assert repository.pushes == ["feature"]
+    assert repository.pushes == ["feature", "feature"]
     assert github.pr_calls[0]["draft"] is True
-    pr_body = github.pr_calls[0]["body"]
+    opening = github.pr_calls[0]["body"]
+    assert "Closes #42" in opening
+    assert "### Problem Statement\n\nproblem" in opening
+    assert "review comments follow on this pull request" in opening
+    assert github.pr_updates[0]["number"] == 1
+    pr_body = github.pr_updates[0]["body"]
     assert "Closes #42" in pr_body
     assert "### Problem Statement\n\nproblem" in pr_body
     assert "### Specification\n\n#### Verdict\n\napprove" in pr_body
@@ -1151,10 +1295,84 @@ def test_each_stage_comments_as_its_configured_github_app(tmp_path: Path) -> Non
         role: client.comments[0][1] for role, client in role_github.items()
     } == expected_keys
     assert all(len(client.comments) == 1 for client in role_github.values())
-    assert {comment[1] for comment in driver_github.comments} == {
+    issue_roles = gdw.ISSUE_COMMENT_ROLES
+    for role, client in role_github.items():
+        number = client.comments[0][0]
+        if role in issue_roles:
+            assert number == 42
+        else:
+            assert number == 1
+    assert {comment[1] for comment in driver_github.comments} == {"ci-implementation-1"}
+    assert driver_github.comments[0][0] == 1
+
+
+def test_specification_is_the_last_issue_comment_and_later_bots_post_on_the_pr(
+    tmp_path: Path,
+) -> None:
+    replies = [
+        _expansion(),
+        _grill(),
+        _specification(),
+        _implementation(),
+        _review(),
+        _review(),
+    ]
+    workflow, github, _repository, _agents = _workflow(tmp_path, replies)
+
+    workflow.run()
+
+    issue_keys = [
+        key for number, key, _title, _payload in github.comments if number == 42
+    ]
+    pr_keys = [key for number, key, _title, _payload in github.comments if number == 1]
+    assert issue_keys == ["expansion-1", "grill-1", "specification"]
+    assert pr_keys == [
+        "implementation",
         "ci-implementation-1",
-        "pull-request",
-    }
+        "review-1-specification",
+        "review-1-quality",
+    ]
+
+
+def test_open_pull_request_reuses_a_recorded_development_pr(tmp_path: Path) -> None:
+    workflow, github, repository, _agents = _workflow(tmp_path, [])
+    workflow.store.record_development_pr(7, "https://example.test/pr/7")
+
+    assert workflow.open_pull_request(_specification()) == "https://example.test/pr/7"
+    assert github.pr_calls == []
+    assert repository.pushes == []
+
+
+def test_open_pull_request_rejects_a_url_without_a_number(tmp_path: Path) -> None:
+    workflow, *_ = _workflow(
+        tmp_path, [], {"github": FakeGitHub("https://example.test/pulls")}
+    )
+    with pytest.raises(gdw.WorkflowError, match="without a number"):
+        workflow.open_pull_request(_specification())
+
+
+def test_resumed_issue_load_collects_pull_request_comment_markers(
+    tmp_path: Path,
+) -> None:
+    workflow, github, _repository, _agents = _workflow(tmp_path, [])
+    workflow.store.record_development_pr(1, "https://example.test/pr/1")
+
+    workflow.load_issue()
+
+    assert github.collected_markers == [1]
+
+
+def test_comment_number_stays_on_the_issue_until_a_pull_request_exists(
+    tmp_path: Path,
+) -> None:
+    workflow, *_ = _workflow(tmp_path, [])
+    assert workflow._comment_number("specifier") == 42
+    assert workflow._comment_number("implementer") == 42
+    assert workflow._comment_number() == 42
+    workflow.store.record_development_pr(9, "https://example.test/pr/9")
+    assert workflow._comment_number("specifier") == 42
+    assert workflow._comment_number("implementer") == 9
+    assert workflow._comment_number() == 9
 
 
 def test_workflow_sends_the_body_once_and_only_five_latest_comments(
@@ -1536,42 +1754,6 @@ def test_prepare_simple_workflow_checks_tools_and_builds_services(
 def test_simple_entrypoint_shows_the_main_flow_and_resumes_completed_work(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:
-    class EntryWorkflow:
-        def __init__(self, completed: str | None) -> None:
-            self.completed = completed
-            self.calls: list[object] = []
-
-        def completed_url(self) -> str | None:
-            self.calls.append("completed")
-            return self.completed
-
-        def load_issue(self) -> dict:
-            self.calls.append("load")
-            return {"issue": 1}
-
-        def clarify(self, issue: dict) -> dict:
-            self.calls.append(("clarify", issue))
-            return {"proposal": 1}
-
-        def specify(self, issue: dict, proposal: dict) -> dict:
-            self.calls.append(("specify", issue, proposal))
-            return {"specification": 1}
-
-        def implement(self, specification: dict) -> None:
-            self.calls.append(("implement", specification))
-
-        def stabilize(self, specification: dict) -> dict:
-            self.calls.append(("stabilize", specification))
-            return {"ci": "green"}
-
-        def review(self, specification: dict, ci: dict) -> dict:
-            self.calls.append(("review", specification, ci))
-            return {"reviews": "approved"}
-
-        def publish(self, specification: dict, reviews: dict) -> str:
-            self.calls.append(("publish", specification, reviews))
-            return "https://example.test/pulls/new"
-
     fresh = EntryWorkflow(None)
     resumed = EntryWorkflow("https://example.test/pulls/existing")
     prepare = MagicMock(side_effect=[fresh, resumed])
@@ -1595,6 +1777,7 @@ def test_simple_entrypoint_shows_the_main_flow_and_resumes_completed_work(
         "load",
         ("clarify", {"issue": 1}),
         ("specify", {"issue": 1}, {"proposal": 1}),
+        ("open_pull_request", {"specification": 1}),
         ("implement", {"specification": 1}),
         ("stabilize", {"specification": 1}),
         ("review", {"specification": 1}, {"ci": "green"}),
@@ -2057,11 +2240,11 @@ def test_a_make_that_cannot_list_its_gates_does_not_stop_ci(
     assert "unstarted gates will go unreported" in caplog.text
 
 
-def test_ci_posts_a_checklist_and_keeps_the_log_off_the_issue(
+def test_ci_posts_a_checklist_and_keeps_the_log_off_github(
     tmp_path: Path,
 ) -> None:
-    """The issue gets the verdict; the evidence stays in the checkpoint and in
-    the repair agent's prompt, where it is actually read."""
+    """The pull request gets the verdict; the evidence stays in the checkpoint
+    and in the repair agent's prompt, where it is actually read."""
     failing = gdw.CommandResult(
         2,
         "uv run ruff check .\nFound 12 errors.",
@@ -2079,6 +2262,7 @@ def test_ci_posts_a_checklist_and_keeps_the_log_off_the_issue(
 
     titles = [comment[2] for comment in github.comments]
     payloads = [comment[3] for comment in github.comments]
+    assert github.comments[0][0] == 1
     assert titles[0] == "CI checks for implementation, attempt 1"
     assert payloads[0] == [
         "❌ lint — Found 12 errors.",


### PR DESCRIPTION
After the specification is posted, Gabriel's development workflow stops commenting on the GitHub issue. That specification is the last bot comment there.

The workflow then opens a draft pull request (empty start-work commit if the branch is not already ahead of base) and posts implementation, CI checklists, repairs, and reviews on that PR. Publish commits the implementation, updates the PR body, and no longer announces the PR on the issue.

Resume still works: the development PR is recorded separately from completion, and a rerun collects comment markers from both the issue and the PR so bots do not repost.