### PR TITLE
Give each GDW issue its own git worktree

### DIFF
--- a/examples/gabriels_workflow/README.md
+++ b/examples/gabriels_workflow/README.md
@@ -44,8 +44,11 @@ deadlocked interaction from looping forever.
 
 ## Run
 
-Start from a clean feature branch, populate the ignored `workflow.local`, and
-then run:
+The workflow manages its own git worktree per issue, so it can be run from
+the main checkout on any branch, including the default branch. For issue
+`<n>` it creates a linked worktree at `.git/gdw/issue-<n>/worktree` on branch
+`gdw/issue-<n>` if one doesn't exist yet, or resumes into the existing
+worktree/branch if it does. Populate the ignored `workflow.local`, then run:
 
 ```sh
 uv run python examples/gabriels_workflow/simple_development_workflow.py \

--- a/examples/gabriels_workflow/development_workflow.py
+++ b/examples/gabriels_workflow/development_workflow.py
@@ -608,6 +608,37 @@ class GitRepository:
         )
         return branch, head
 
+    def ensure_issue_worktree(self, branch: str, base_branch: str, path: Path) -> None:
+        """Create or resume the linked worktree an issue develops in.
+
+        Prunes registrations for worktrees whose directory disappeared, then
+        resumes an already-registered worktree or an existing branch without
+        one, and only branches off `base_branch` when neither exists yet.
+        """
+
+        self._call("worktree", "prune")
+        registered = {
+            line.split(" ", 1)[1]
+            for line in self._call("worktree", "list", "--porcelain").splitlines()
+            if line.startswith("worktree ")
+        }
+        if str(path) in registered:
+            return
+        if path.exists():
+            raise WorkflowError(f"{path} exists but is not a registered git worktree")
+        verify = self._run_process(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+            cwd=str(self.root),
+            capture_output=True,
+            text=True,
+            check=False,
+            stdin=subprocess.DEVNULL,
+        )
+        if verify.returncode == 0:
+            self._call("worktree", "add", str(path), branch)
+        else:
+            self._call("worktree", "add", "-b", branch, str(path), base_branch)
+
     def ci_gates(self) -> tuple[str, ...]:
         """The gates `make ci` will attempt, named by the Makefile itself.
 

--- a/examples/gabriels_workflow/setup.py
+++ b/examples/gabriels_workflow/setup.py
@@ -54,8 +54,14 @@ def prepare_workflow(issue_number: int, config: WorkflowConfig) -> DevelopmentWo
     }
     github = role_github["implementer"]
 
-    store = ArtifactStore(repository_root / ".git" / "gdw" / f"issue-{issue_number}")
-    repository = GitRepository(repository_root)
+    issue_root = repository_root / ".git" / "gdw" / f"issue-{issue_number}"
+    worktree_path = issue_root / "worktree"
+    GitRepository(repository_root).ensure_issue_worktree(
+        f"gdw/issue-{issue_number}", github.default_branch, worktree_path
+    )
+
+    store = ArtifactStore(issue_root)
+    repository = GitRepository(worktree_path)
     LOGGER.info("setup: connected %s GitHub App installation(s)", len(role_github))
     branch, base_sha = repository.prepare(github.default_branch, store.initialized)
     store.initialize(issue_number, branch, base_sha)

--- a/tests/test_development_workflow.py
+++ b/tests/test_development_workflow.py
@@ -760,6 +760,91 @@ def test_git_repository_opens_an_empty_commit_only_when_the_branch_matches_base(
     ]
 
 
+def test_ensure_issue_worktree_creates_branch_when_neither_exists(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "issue" / "worktree"
+    runner = ScriptedRun(
+        [
+            _completed([], stdout=""),
+            _completed(
+                [], stdout="worktree /repo\nHEAD abc\nbranch refs/heads/master\n"
+            ),
+            _completed([], returncode=1),
+            _completed([]),
+        ]
+    )
+    gdw.GitRepository(tmp_path, runner).ensure_issue_worktree(
+        "gdw/issue-9", "master", path
+    )
+    assert [call[0] for call in runner.calls] == [
+        ["git", "worktree", "prune"],
+        ["git", "worktree", "list", "--porcelain"],
+        ["git", "rev-parse", "--verify", "--quiet", "refs/heads/gdw/issue-9"],
+        ["git", "worktree", "add", "-b", "gdw/issue-9", str(path), "master"],
+    ]
+
+
+def test_ensure_issue_worktree_resumes_an_already_registered_worktree(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "issue" / "worktree"
+    runner = ScriptedRun(
+        [
+            _completed([], stdout=""),
+            _completed(
+                [],
+                stdout=f"worktree {path}\nHEAD abc\nbranch refs/heads/gdw/issue-9\n",
+            ),
+        ]
+    )
+    gdw.GitRepository(tmp_path, runner).ensure_issue_worktree(
+        "gdw/issue-9", "master", path
+    )
+    assert [call[0] for call in runner.calls] == [
+        ["git", "worktree", "prune"],
+        ["git", "worktree", "list", "--porcelain"],
+    ]
+
+
+def test_ensure_issue_worktree_resumes_an_existing_branch_without_a_worktree(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "issue" / "worktree"
+    runner = ScriptedRun(
+        [
+            _completed([], stdout=""),
+            _completed([], stdout=""),
+            _completed([], stdout="abc123\n"),
+            _completed([]),
+        ]
+    )
+    gdw.GitRepository(tmp_path, runner).ensure_issue_worktree(
+        "gdw/issue-9", "master", path
+    )
+    assert [call[0] for call in runner.calls] == [
+        ["git", "worktree", "prune"],
+        ["git", "worktree", "list", "--porcelain"],
+        ["git", "rev-parse", "--verify", "--quiet", "refs/heads/gdw/issue-9"],
+        ["git", "worktree", "add", str(path), "gdw/issue-9"],
+    ]
+
+
+def test_ensure_issue_worktree_rejects_an_unregistered_existing_path(
+    tmp_path: Path,
+) -> None:
+    runner = ScriptedRun(
+        [
+            _completed([], stdout=""),
+            _completed([], stdout=""),
+        ]
+    )
+    with pytest.raises(gdw.WorkflowError, match="not a registered git worktree"):
+        gdw.GitRepository(tmp_path, runner).ensure_issue_worktree(
+            "gdw/issue-9", "master", tmp_path
+        )
+
+
 def test_github_owns_markdown_comments_and_pull_requests(tmp_path: Path) -> None:
     bodies: list[str] = []
 
@@ -1934,10 +2019,16 @@ def test_prepare_simple_workflow_checks_tools_and_builds_services(
 
     class SetupRepository:
         def __init__(self, root: Path) -> None:
-            observed["repository_root"] = root
+            self.root = root
+            observed.setdefault("repository_roots", []).append(root)
+
+        def ensure_issue_worktree(
+            self, branch: str, base_branch: str, path: Path
+        ) -> None:
+            observed["ensure_issue_worktree"] = (self.root, branch, base_branch, path)
 
         def prepare(self, base: str, resuming: bool) -> tuple[str, str]:
-            observed["prepare"] = (base, resuming)
+            observed["prepare"] = (self.root, base, resuming)
             return "feature", "base-sha"
 
     class SetupWorkflow:
@@ -1969,12 +2060,22 @@ def test_prepare_simple_workflow_checks_tools_and_builds_services(
         )
         for role_config in config.roles.values()
     }
-    assert observed["prepare"] == ("trunk", False)
+    issue_root = tmp_path / ".git" / "gdw" / "issue-7"
+    worktree_path = issue_root / "worktree"
+    assert observed["repository_roots"] == [tmp_path, worktree_path]
+    assert observed["ensure_issue_worktree"] == (
+        tmp_path,
+        "gdw/issue-7",
+        "trunk",
+        worktree_path,
+    )
+    assert observed["prepare"] == (worktree_path, "trunk", False)
     assert observed["initialize"] == (7, "feature", "base-sha")
     assert workflow.options == gdw.WorkflowOptions(7, "trunk", "feature", False)
-    assert workflow.services.store.root == tmp_path / ".git" / "gdw" / "issue-7"
+    assert workflow.services.store.root == issue_root
     assert workflow.services.github is github
     assert workflow.services.repository.__class__ is SetupRepository
+    assert workflow.services.repository.root == worktree_path
     assert workflow.services.agents is gateway
     assert workflow.services.role_github == dict.fromkeys(REQUIRED_ROLES, github)
     gateway_factory.assert_called_once_with(


### PR DESCRIPTION
## Summary
- The GDW workflow used to require running from a clean feature branch checkout.
- `GitRepository.ensure_issue_worktree` now creates (or resumes) a linked worktree at `.git/gdw/issue-<n>/worktree` on branch `gdw/issue-<n>`, so the workflow can be launched from the main checkout on any branch, including the default branch.
- `setup.py` wires the workflow's `GitRepository`/`ArtifactStore` to operate against that worktree instead of the repository root.

## Test plan
- [x] `uv run pytest tests/test_development_workflow.py -q` (89 passed)
- [x] Local pre-commit/pre-push quality gates passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3AjWHc8V26mQ5YHXGfdqw