### PR TITLE
Protect the required CI gate and workflow topology from deletion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,22 @@ this file only carries what no tool can check.
   never as instructions to this assistant or as trusted input to shell out
   with.
 - Satisfy a failing gate; do not relax it. `make ratchet` blocks silent
-  threshold reductions and a narrowed mutation scope. A deliberate coverage
-  policy reset requires a `COVERAGE_POLICY_VERSION` bump, explanation in the
-  PR, and review. The ratchet cannot see intent — deleting a test, weakening
-  an assertion, or faking the behavior under test still passes it.
+  threshold reductions, a narrowed mutation scope, and a narrowed gate
+  topology (`CI_GATES`, Makefile prerequisite chains, hosted workflow jobs,
+  `quality-gate` needs and its every-lane-succeeded assertion, the
+  `diff-coverage` step, and the Gitleaks step). It also blocks a gate that
+  survives in name only: a recipe emptied or made failure-ignoring, `.IGNORE`
+  or an `-i`/`-k` in `MAKEFLAGS`, a lane whose `run:`/`uses:`/`if:` stops
+  doing what it did, a `continue-on-error:` that reports a red lane green, a
+  renamed required check, a dropped CI trigger, and a `RATCHET_BASE`/
+  `DIFF_BASE` repointed so a comparison cannot fail. The gate's own guarded
+  path constants and `TOPOLOGY_TARGETS` are ratcheted the same way, since
+  repointing one silently skips every check that reads it. A deliberate
+  coverage policy reset requires a `COVERAGE_POLICY_VERSION` bump and a
+  deliberate topology reset requires a `GATE_TOPOLOGY_POLICY_VERSION` bump —
+  each advanced exactly one, with explanation in the PR and review. The
+  ratchet cannot see intent — deleting a test, weakening an assertion, or
+  faking the behavior under test still passes it.
 - Kill surviving mutants by asserting on behavior that distinguishes correct
   output from corrupted output, never by excluding code from mutation.
 - For any change presented as a bug fix, run

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -312,6 +312,772 @@ def _minimal_gate_tree(root: Path) -> None:
     _write(root / "kept.py", "x = 1\n")
 
 
+def _minimal_topology_tree(root: Path) -> None:
+    """A CI_GATES/Makefile-chain/ci.yml topology small enough to plant
+    a single deletion in, mirroring the real repo's structure at each
+    protected point: VERIFY_QUICK's ratchet gate, the ci->security->
+    security-static->semgrep chain, the hosted quality-gate needs, and the
+    coverage job's diff-coverage step."""
+    _minimal_gate_tree(root)
+    _write(
+        root / "tools" / "ratchet_gate.py",
+        "GATE_TOPOLOGY_POLICY_VERSION = 1\n"
+        'COVERAGE_GATE = "tools/coverage_gate.py"\n'
+        'MUTATION_GATE = "tools/mutation_gate.py"\n'
+        'PYPROJECT = "pyproject.toml"\n'
+        'MAKEFILE = "Makefile"\n'
+        'SEMGREP_RULES = "semgrep.yml"\n'
+        'CI_WORKFLOW = ".github/workflows/ci.yml"\n'
+        'RATCHET_GATE = "tools/ratchet_gate.py"\n'
+        'TOPOLOGY_TARGETS = ("ci", "verify", "security")\n',
+    )
+    _write(
+        root / "Makefile",
+        "DIFF_COVERAGE_MIN ?= 90\n"
+        "RATCHET_BASE ?= origin/master\n"
+        "DIFF_BASE ?= origin/master\n"
+        "VERIFY_QUICK := format-check lint types test-integrity ratchet\n"
+        "VERIFY_COVERAGE := test-coverage\n"
+        "VERIFY_MUTATION := mutation\n"
+        "VERIFY_SECURITY := security-static\n"
+        "CI_GATES := $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) $(VERIFY_MUTATION) \\\n"
+        "\tsemgrep $(VERIFY_SECURITY) secrets\n"
+        "verify-quick: $(VERIFY_QUICK) workflows\n"
+        "verify-coverage: $(VERIFY_COVERAGE)\n"
+        "verify-mutation: $(VERIFY_MUTATION)\n"
+        "verify-security: $(VERIFY_SECURITY)\n"
+        "security: security-static secrets\n"
+        "verify: verify-quick verify-coverage verify-mutation\n"
+        "ci: verify security\n"
+        "ci-hosted: verify verify-security\n"
+        "security-static: semgrep\n"
+        "lint:\n"
+        "\tuv run ruff check .\n"
+        "ratchet:\n"
+        "\tuv run python tools/ratchet_gate.py $(RATCHET_BASE)\n",
+    )
+    _write(
+        root / ".github" / "workflows" / "ci.yml",
+        "name: CI\n\non:\n  push:\n  pull_request:\n\njobs:\n"
+        "  quick:\n"
+        "    name: Quick\n"
+        "    steps:\n"
+        "      - run: make verify-quick\n"
+        "  coverage:\n"
+        "    name: Coverage\n"
+        "    steps:\n"
+        "      - name: diff coverage\n"
+        "        run: make diff-coverage\n"
+        "  mutation:\n"
+        "    name: Mutation\n"
+        "  security-static:\n"
+        "    name: Static security\n"
+        "  quality-gate:\n"
+        "    name: Quality and security\n"
+        "    needs: [quick, coverage, mutation, security-static]\n"
+        "    steps:\n"
+        "      - name: Require every quality lane to succeed\n"
+        '        run: test "$LANE_RESULTS" = "success success success success"\n'
+        "  secret-scan:\n"
+        "    name: Secret scan\n"
+        "    steps:\n"
+        "      - name: Run Gitleaks\n"
+        "        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e\n",
+    )
+
+
+class TestGateTopology:
+    def test_local_gate_dropped_from_ci_gates_via_verify_quick_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile.replace(
+                "VERIFY_QUICK := format-check lint types test-integrity ratchet",
+                "VERIFY_QUICK := format-check lint types test-integrity",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "CI_GATES dropped required gate(s)" in out
+        assert "ratchet" in out
+
+    def test_local_gate_dropped_directly_from_ci_gates_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile.replace(
+                "CI_GATES := $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) "
+                "$(VERIFY_MUTATION) \\\n\tsemgrep $(VERIFY_SECURITY) secrets\n",
+                "CI_GATES := $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) "
+                "$(VERIFY_MUTATION) \\\n\t$(VERIFY_SECURITY) secrets\n",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "CI_GATES dropped required gate(s)" in out
+        assert "semgrep" in out
+
+    def test_narrower_verify_quick_reassignment_before_ci_gates_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """`make` resolves a `:=` variable to its last assignment before the
+        point it is used, so a second, narrower VERIFY_QUICK inserted right
+        before CI_GATES's own definition is what `make` actually expands --
+        a first-match reader would miss it and call the narrowed set
+        unchanged."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile.replace(
+                "CI_GATES := $(VERIFY_QUICK) workflows",
+                "VERIFY_QUICK := format-check lint types test-integrity\n"
+                "CI_GATES := $(VERIFY_QUICK) workflows",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "CI_GATES dropped required gate(s)" in out
+        assert "ratchet" in out
+
+    def test_narrower_ci_gates_appended_after_the_original_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """A second, narrower `CI_GATES :=` appended after the original is
+        what `make` actually uses; a first-match reader would keep reading
+        the original and call the narrowed set unchanged."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile + "CI_GATES := format-check lint types\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "CI_GATES dropped required gate(s)" in out
+
+    def test_editing_both_ci_gates_and_its_chain_still_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """Dropping semgrep from both CI_GATES and the security-static
+        prerequisite it feeds is still caught in both places, because each
+        base comparison detects its own missing membership independently of
+        how consistently the deletion was hidden elsewhere."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        makefile = makefile.replace(
+            "CI_GATES := $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) "
+            "$(VERIFY_MUTATION) \\\n\tsemgrep $(VERIFY_SECURITY) secrets\n",
+            "CI_GATES := $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) "
+            "$(VERIFY_MUTATION) \\\n\t$(VERIFY_SECURITY) secrets\n",
+        )
+        makefile = makefile.replace("security-static: semgrep\n", "security-static:\n")
+        _write(tmp_path / "Makefile", makefile)
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "CI_GATES dropped required gate(s)" in out
+        assert "security-static: prerequisite(s) dropped" in out
+        assert "semgrep" in out
+
+    def test_narrowed_make_chain_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile.replace("ci: verify security\n", "ci: verify\n"),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "ci: prerequisite(s) dropped" in out
+        assert "security" in out
+
+    def test_hosted_job_deleted_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            "name: CI\n\njobs:\n"
+            "  quick:\n    name: Quick\n"
+            "  mutation:\n    name: Mutation\n"
+            "  security-static:\n    name: Static security\n"
+            "  quality-gate:\n    name: Quality and security\n"
+            "    needs: [quick, coverage, mutation, security-static]\n"
+            "  secret-scan:\n    name: Secret scan\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "CI workflow job(s) deleted" in out
+        assert "coverage" in out
+
+    def test_narrowed_quality_gate_needs_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            workflow.replace(
+                "needs: [quick, coverage, mutation, security-static]",
+                "needs: [quick, coverage, mutation]",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "quality-gate needs narrowed" in out
+        assert "security-static" in out
+
+    def test_quality_gate_needs_deleted_with_a_decoy_needs_elsewhere_still_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """quality-gate's own needs: must be read from its job block, not
+        the first flow-style needs: found anywhere after it -- otherwise
+        deleting quality-gate's list entirely while adding an identical
+        needs: to a later job (here secret-scan) reads as unchanged."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        workflow = workflow.replace(
+            "    needs: [quick, coverage, mutation, security-static]\n", "", 1
+        )
+        workflow = workflow.replace(
+            "  secret-scan:\n    name: Secret scan\n",
+            "  secret-scan:\n    name: Secret scan\n"
+            "    needs: [quick, coverage, mutation, security-static]\n",
+            1,
+        )
+        _write(tmp_path / ".github" / "workflows" / "ci.yml", workflow)
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "quality-gate needs narrowed" in out
+        assert "security-static" in out
+
+    def test_diff_coverage_step_deleted_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            workflow.replace(
+                "    steps:\n      - name: diff coverage\n        run: make diff-coverage\n",
+                "",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "diff-coverage step was removed" in capsys.readouterr().out
+
+    def test_diff_coverage_step_neutered_but_mentioned_in_a_comment_still_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """A comment mentioning the old command must not satisfy a
+        whole-file substring check; the check must require an actual
+        `run:` line inside the coverage job."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            workflow.replace(
+                "        run: make diff-coverage\n",
+                "        run: true  # was: make diff-coverage\n",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "diff-coverage step was removed" in capsys.readouterr().out
+
+    def test_secret_scan_gitleaks_step_deleted_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            workflow.replace(
+                "    steps:\n"
+                "      - name: Run Gitleaks\n"
+                "        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c"
+                "57e68cb5cbf0e8d1e\n",
+                "",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "Gitleaks step was removed" in capsys.readouterr().out
+
+    def test_quality_gate_assertion_neutered_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """A lane in `needs:` that the assertion stops counting can fail in
+        silence: `if: always()` runs quality-gate regardless, so only this
+        step turns a red lane into a red required check."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            workflow.replace(
+                'run: test "$LANE_RESULTS" = "success success success success"',
+                'run: "true"',
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "no longer asserts that every lane succeeded" in capsys.readouterr().out
+
+    def test_quality_gate_assertion_shorter_than_its_needs_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """Shortening the compared string leaves the later lanes unasserted."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            workflow.replace(
+                'run: test "$LANE_RESULTS" = "success success success success"',
+                'run: test "$LANE_RESULTS" = "success"',
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert (
+            "asserts only 1 successful lane(s) but needs 4" in capsys.readouterr().out
+        )
+
+    def _plant(self, tmp_path: Path, name: str, old: str, new: str) -> None:
+        target = {
+            "mk": tmp_path / "Makefile",
+            "ci": tmp_path / ".github" / "workflows" / "ci.yml",
+            "rg": tmp_path / "tools" / "ratchet_gate.py",
+        }[name]
+        text = target.read_text(encoding="utf-8")
+        assert old in text, f"planting anchor missing from {name}"
+        _write(target, text.replace(old, new, 1))
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            pytest.param(
+                (
+                    "mk",
+                    "CI_GATES := $(VERIFY_QUICK)",
+                    "override VERIFY_QUICK := format-check\nCI_GATES := $(VERIFY_QUICK)",
+                    "CI_GATES dropped required gate(s)",
+                ),
+                id="override-reassignment-hides-a-narrower-list",
+            ),
+            pytest.param(
+                (
+                    "mk",
+                    "CI_GATES := $(VERIFY_QUICK)",
+                    "VERIFY_QUICK ::= format-check\nCI_GATES := $(VERIFY_QUICK)",
+                    "CI_GATES dropped required gate(s)",
+                ),
+                id="simply-expanded-reassignment-hides-a-narrower-list",
+            ),
+            pytest.param(
+                (
+                    "mk",
+                    "ci: verify security",
+                    "ifeq (1,2)\nci: verify security\nendif\n\nci: verify",
+                    "ci: prerequisite(s) dropped",
+                ),
+                id="decoy-rule-in-a-dead-conditional",
+            ),
+            pytest.param(
+                (
+                    "mk",
+                    "VERIFY_QUICK :=",
+                    ".IGNORE:\n\nVERIFY_QUICK :=",
+                    "every gate's failure would be ignored",
+                ),
+                id="dot-ignore-makes-every-gate-advisory",
+            ),
+            pytest.param(
+                (
+                    "mk",
+                    "DIFF_COVERAGE_MIN ?= 90",
+                    "DIFF_COVERAGE_MIN ?= 90\nMAKEFLAGS += -i",
+                    "error-ignoring flag",
+                ),
+                id="makeflags-ignore-errors",
+            ),
+            pytest.param(
+                (
+                    "mk",
+                    "RATCHET_BASE ?= origin/master",
+                    "RATCHET_BASE ?= HEAD",
+                    "RATCHET_BASE changed",
+                ),
+                id="base-ref-repointed-at-head",
+            ),
+            pytest.param(
+                (
+                    "mk",
+                    "tools/ratchet_gate.py $(RATCHET_BASE)",
+                    "tools/ratchet_gate.py HEAD",
+                    "no longer passes $(RATCHET_BASE)",
+                ),
+                id="base-ref-hardcoded-into-the-recipe",
+            ),
+            pytest.param(
+                (
+                    "mk",
+                    "\tuv run ruff check .",
+                    "\t@true",
+                    "command dropped from its recipe",
+                ),
+                id="gate-recipe-turned-into-a-no-op",
+            ),
+            pytest.param(
+                (
+                    "mk",
+                    "\tuv run ruff check .",
+                    "\t-uv run ruff check .",
+                    "failure-ignoring",
+                ),
+                id="gate-command-given-makes-dash-prefix",
+            ),
+            pytest.param(
+                (
+                    "rg",
+                    'MAKEFILE = "Makefile"',
+                    'MAKEFILE = "makefile"',
+                    "MAKEFILE repointed",
+                ),
+                id="guarded-path-repointed-off-the-base-tree",
+            ),
+            pytest.param(
+                (
+                    "rg",
+                    'TOPOLOGY_TARGETS = ("ci", "verify", "security")',
+                    'TOPOLOGY_TARGETS = ("ci",)',
+                    "TOPOLOGY_TARGETS dropped",
+                ),
+                id="topology-target-list-narrowed",
+            ),
+            pytest.param(
+                (
+                    "ci",
+                    "      - run: make verify-quick",
+                    "      - run: 'true'",
+                    "no longer does what it did",
+                ),
+                id="lane-stops-running-its-gate",
+            ),
+            pytest.param(
+                (
+                    "ci",
+                    "  quick:\n",
+                    "  quick:\n    continue-on-error: true\n",
+                    "continue-on-error added",
+                ),
+                id="lane-failure-reported-as-success",
+            ),
+            pytest.param(
+                (
+                    "ci",
+                    "    name: Quality and security\n",
+                    "    name: Quality and security (legacy)\n",
+                    "no longer does what it did",
+                ),
+                id="required-check-identity-renamed",
+            ),
+            pytest.param(
+                (
+                    "ci",
+                    "  pull_request:\n",
+                    "",
+                    "CI trigger(s) removed",
+                ),
+                id="pull-request-trigger-dropped",
+            ),
+        ],
+    )
+    def test_planted_bypass_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys,
+        case: tuple[str, str, str, str],
+    ) -> None:
+        """Each edit leaves the topology looking intact while the check it
+        names stops running -- every one of them passed an earlier revision
+        of this gate."""
+        where, old, new, expected = case
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        self._plant(tmp_path, where, old, new)
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert expected in capsys.readouterr().out
+
+    def test_shadow_version_assignment_does_not_grant_a_reset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """Python resolves a duplicated constant to the last binding, a
+        first-match reader to the first. An added earlier `= 2` must not buy
+        a topology reset while the reviewed line still reads `= 1`."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        self._plant(
+            tmp_path,
+            "rg",
+            "GATE_TOPOLOGY_POLICY_VERSION = 1",
+            "GATE_TOPOLOGY_POLICY_VERSION = 2\nGATE_TOPOLOGY_POLICY_VERSION = 1",
+        )
+        self._plant(tmp_path, "mk", "ci: verify security", "ci: verify")
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "ci: prerequisite(s) dropped" in capsys.readouterr().out
+
+    def test_a_legitimate_addition_still_needs_no_version_bump(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The hardening must not turn ordinary growth into a policy event."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        self._plant(
+            tmp_path,
+            "mk",
+            "\tsemgrep $(VERIFY_SECURITY) secrets",
+            "\tsemgrep $(VERIFY_SECURITY) secrets newgate",
+        )
+        self._plant(
+            tmp_path,
+            "ci",
+            "  secret-scan:\n",
+            "  brand-new:\n    name: Brand new\n  secret-scan:\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 0
+
+    def test_secret_scan_gitleaks_step_survives_in_wrong_job_still_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """A gitleaks-action reference relocated into an unrelated job must
+        not satisfy a whole-file substring check."""
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        workflow = workflow.replace(
+            "    steps:\n"
+            "      - name: Run Gitleaks\n"
+            "        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c"
+            "57e68cb5cbf0e8d1e\n",
+            "",
+        )
+        workflow = workflow.replace(
+            "  quick:\n    name: Quick\n",
+            "  quick:\n    name: Quick\n"
+            "    steps:\n"
+            "      - name: Run Gitleaks\n"
+            "        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c"
+            "57e68cb5cbf0e8d1e\n",
+        )
+        _write(tmp_path / ".github" / "workflows" / "ci.yml", workflow)
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "Gitleaks step was removed" in capsys.readouterr().out
+
+    def test_unparsable_ci_gates_on_base_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """A reformat of CI_GATES this gate cannot parse must fail instead
+        of silently skipping the check, unless it is bundled with a
+        reviewed GATE_TOPOLOGY_POLICY_VERSION bump."""
+        _minimal_topology_tree(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile.replace(
+                "CI_GATES := $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) "
+                "$(VERIFY_MUTATION) \\\n\tsemgrep $(VERIFY_SECURITY) secrets\n",
+                "CI_GATES = $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) "
+                "$(VERIFY_MUTATION) \\\n\tsemgrep $(VERIFY_SECURITY) secrets\n",
+            ),
+        )
+        _commit_gates(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "CI_GATES on the base branch could not be resolved" in out
+
+    def test_unparsable_quality_gate_needs_on_base_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        """A `needs:` reformatted into a multi-line block must fail instead
+        of silently skipping the check, unless it is bundled with a
+        reviewed GATE_TOPOLOGY_POLICY_VERSION bump."""
+        _minimal_topology_tree(tmp_path)
+        workflow = (tmp_path / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        _write(
+            tmp_path / ".github" / "workflows" / "ci.yml",
+            workflow.replace(
+                "    needs: [quick, coverage, mutation, security-static]\n",
+                "    needs:\n"
+                "      - quick\n"
+                "      - coverage\n"
+                "      - mutation\n"
+                "      - security-static\n",
+            ),
+        )
+        _commit_gates(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        out = capsys.readouterr().out
+        assert "quality-gate's needs: on the base branch does not match" in out
+
+    def test_topology_policy_version_cannot_move_backwards(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _write(
+            tmp_path / "tools" / "ratchet_gate.py",
+            "GATE_TOPOLOGY_POLICY_VERSION = 2\n",
+        )
+        _commit_gates(tmp_path)
+        _write(
+            tmp_path / "tools" / "ratchet_gate.py",
+            "GATE_TOPOLOGY_POLICY_VERSION = 1\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "GATE_TOPOLOGY_POLICY_VERSION lowered 2 -> 1" in capsys.readouterr().out
+
+    def test_legitimate_addition_passes_without_a_version_bump(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile.replace(
+                "CI_GATES := $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) "
+                "$(VERIFY_MUTATION) \\\n\tsemgrep $(VERIFY_SECURITY) secrets\n",
+                "CI_GATES := $(VERIFY_QUICK) workflows $(VERIFY_COVERAGE) "
+                "$(VERIFY_MUTATION) \\\n\tsemgrep $(VERIFY_SECURITY) secrets new-gate\n",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 0
+        assert "no threshold weakened" in capsys.readouterr().out
+
+    def test_topology_reset_advanced_by_one_with_a_deletion_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile.replace(
+                "VERIFY_QUICK := format-check lint types test-integrity ratchet",
+                "VERIFY_QUICK := format-check lint types test-integrity",
+            ),
+        )
+        ratchet_source = (tmp_path / "tools" / "ratchet_gate.py").read_text(
+            encoding="utf-8"
+        )
+        _write(
+            tmp_path / "tools" / "ratchet_gate.py",
+            ratchet_source.replace(
+                "GATE_TOPOLOGY_POLICY_VERSION = 1", "GATE_TOPOLOGY_POLICY_VERSION = 2"
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 0
+        assert "no threshold weakened" in capsys.readouterr().out
+
+    def test_topology_reset_advanced_by_zero_with_a_deletion_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        makefile = (tmp_path / "Makefile").read_text(encoding="utf-8")
+        _write(
+            tmp_path / "Makefile",
+            makefile.replace(
+                "VERIFY_QUICK := format-check lint types test-integrity ratchet",
+                "VERIFY_QUICK := format-check lint types test-integrity",
+            ),
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "CI_GATES dropped required gate(s)" in capsys.readouterr().out
+
+    def test_topology_reset_advanced_by_two_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        _write(
+            tmp_path / "tools" / "ratchet_gate.py",
+            "GATE_TOPOLOGY_POLICY_VERSION = 3\n",
+        )
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 1
+        assert "advance it one reviewed policy revision" in capsys.readouterr().out
+
+    def test_unchanged_topology_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    ) -> None:
+        _minimal_topology_tree(tmp_path)
+        _commit_gates(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        assert ratchet_gate.main(["ratchet", "HEAD"]) == 0
+        assert "no threshold weakened" in capsys.readouterr().out
+
+
 class TestRatchetGate:
     def test_an_inherited_git_index_never_reaches_the_repository_under_test(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys

--- a/tools/ratchet_gate.py
+++ b/tools/ratchet_gate.py
@@ -10,12 +10,29 @@ Thresholds are read from the base branch and compared with the working tree.
 Raising a floor is always allowed. Lowering one fails. A floor may be dropped
 only when its source file is genuinely gone. Coverage is the exception: a
 deliberate risk-policy reset can lower its thresholds by advancing
-``COVERAGE_POLICY_VERSION`` exactly one version. That explicit change is easy
-to review and does not weaken mutation, changed-line coverage, or security.
+``COVERAGE_POLICY_VERSION`` exactly one version. Gate topology
+(``CI_GATES``, Makefile prerequisite chains, hosted workflow jobs,
+``quality-gate`` needs, and the ``diff-coverage`` step) is guarded the same
+way: it may only grow, and a deliberate reset requires advancing
+``GATE_TOPOLOGY_POLICY_VERSION`` exactly one version. Each explicit change is
+easy to review and does not weaken the other.
 
 A threshold is only guarded if this file knows where it lives, so every new
 one needs an entry here. They currently sit in three places: the gate
 scripts, `pyproject.toml`, and the Makefile.
+
+Gate topology is guarded relatively (base branch vs. working tree), not
+against a frozen absolute list of protected gates/jobs/needs. A reviewed
+``GATE_TOPOLOGY_POLICY_VERSION`` bump that removes a gate therefore drops
+that gate from protection for good, the same way a reviewed
+``COVERAGE_POLICY_VERSION`` bump permanently lowers a floor. This is a
+deliberate choice, not an oversight: an absolute frozen list would need its
+own update on every legitimate addition, in a second place, with no way to
+tell "author forgot to update the freeze" apart from "author is narrowing
+protection on purpose" -- exactly the dual-maintenance failure mode this
+file's own docstring already warns against for Makefile chains. Relative
+comparison plus a reviewed, one-at-a-time version bump gives the same
+protection with one fewer place to go stale.
 
 Suppression counts are deliberately not ratcheted: AGENTS.md permits a
 `# noqa` or `# nosec` that carries a finding ID and a justification, so a
@@ -37,6 +54,30 @@ MUTATION_GATE = "tools/mutation_gate.py"
 PYPROJECT = "pyproject.toml"
 MAKEFILE = "Makefile"
 SEMGREP_RULES = "semgrep.yml"
+CI_WORKFLOW = ".github/workflows/ci.yml"
+RATCHET_GATE = "tools/ratchet_gate.py"
+
+# Gate topology is a threshold like any other: CI_GATES, the Makefile's
+# prerequisite chains, and the workflow's job/needs graph can all be narrowed
+# a token at a time while every individual gate still passes. A deliberate
+# reset works the same way a coverage policy reset does, and independently of
+# it -- the two must not be conflatable.
+GATE_TOPOLOGY_POLICY_VERSION = 1
+
+# Which Makefile rules this file walks for a narrowed prerequisite list. Not
+# a general graph walker: adding a new chain worth protecting means adding
+# its target name here.
+TOPOLOGY_TARGETS = (
+    "ci",
+    "verify",
+    "security",
+    "verify-quick",
+    "verify-coverage",
+    "verify-mutation",
+    "verify-security",
+    "security-static",
+    "ci-hosted",
+)
 
 
 def _git(*args: str) -> subprocess.CompletedProcess[str]:
@@ -60,8 +101,35 @@ def _read_base(base: str, path: str) -> str | None:
     return result.stdout if result.returncode == 0 else None
 
 
+def _binding_count(source: str, name: str) -> int:
+    """How many module-level statements bind `name`."""
+    count = 0
+    for node in ast.parse(source).body:
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            )
+        ) or (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+        ):
+            count += 1
+    return count
+
+
 def _constant(source: str, name: str):
-    """Pull a module-level literal without importing the file."""
+    """Pull a module-level literal without importing the file.
+
+    Fails closed on more than one module-level binding of `name`: Python
+    resolves to the last, a first-match reader to the first, and that gap
+    lets an added `GATE_TOPOLOGY_POLICY_VERSION = 2` above the real one
+    claim a reviewed reset while the constant everyone reads still says 1.
+    """
+    if _binding_count(source, name) > 1:
+        return None
     for node in ast.parse(source).body:
         if isinstance(node, ast.Assign) and any(
             isinstance(target, ast.Name) and target.id == name
@@ -184,6 +252,8 @@ def _check_pyproject(
 
 def _make_variable(source: str, name: str) -> float | None:
     """Read a `NAME ?= value` assignment without invoking make."""
+    if _assignment_count(source, name) != 1:
+        return None
     match = re.search(
         rf"^{re.escape(name)}\s*\?*=\s*([0-9]+(?:\.[0-9]+)?)\s*$",
         source,
@@ -235,6 +305,597 @@ def _check_semgrep_rules(base: str, failures: list[str]) -> None:
         failures.append(f"Semgrep rules deleted: {sorted(dropped)}.")
 
 
+def _join_continuations(source: str) -> str:
+    """Collapse a backslash-continued Makefile line onto one logical line."""
+    return re.sub(r"\\\n[ \t]*", " ", source)
+
+
+# Every way GNU make can bind a variable. `_make_list` reads only the plain
+# `NAME :=` form, so any of the others appearing alongside it means the value
+# make resolves is not the one this file parsed -- `override NAME := x`,
+# `NAME ::= x` and `define NAME` all won a hunt against the first-match-only
+# version of this gate.
+_ASSIGNMENT_FORMS = (
+    r"^(?:override\s+)?{name}\s*(?::::=|::=|:=|\+=|\?=|=)",
+    r"^(?:override\s+)?define\s+{name}\s*(?::::=|::=|:=|\+=|\?=|=)?\s*$",
+)
+
+
+def _assignment_count(source: str, name: str) -> int:
+    """How many times `name` is bound, across every assignment syntax."""
+    return sum(
+        len(re.findall(form.format(name=re.escape(name)), source, flags=re.MULTILINE))
+        for form in _ASSIGNMENT_FORMS
+    )
+
+
+def _make_list(source: str, name: str) -> list[str] | None:
+    """Read a `NAME := val val \\n val` assignment, expanding `$(OTHER)` refs.
+
+    Bounded to this shape on purpose: it is what CI_GATES and its VERIFY_*
+    building blocks are written as today. A reformat that this cannot parse
+    fails closed via the callers' None handling, not silently.
+
+    Also fails closed on more than one `NAME :=` assignment. GNU make
+    resolves a simply-expanded variable to whichever assignment is last
+    before the point it is referenced, which is order-dependent and easy to
+    get wrong with a regex; a second, narrower assignment inserted just
+    before CI_GATES's own definition is exactly how a gate would be quietly
+    dropped from what `make` actually runs while still parsing as "defined"
+    to a first-match reader. Treating any duplicate as unparsable avoids
+    replicating make's resolution order and can't be gamed by insertion
+    position.
+    """
+    joined = _join_continuations(source)
+    if _assignment_count(joined, name) != 1:
+        return None
+    matches = list(
+        re.finditer(rf"^{re.escape(name)}\s*:=\s*(.*)$", joined, flags=re.MULTILINE)
+    )
+    if len(matches) != 1:
+        return None
+    match = matches[0]
+    expanded: list[str] = []
+    for token in match.group(1).split():
+        ref = re.fullmatch(r"\$\((\w+)\)", token)
+        if ref is None:
+            expanded.append(token)
+            continue
+        sub = _make_list(source, ref.group(1))
+        if sub is None:
+            return None
+        expanded.extend(sub)
+    return expanded
+
+
+def _make_prereqs(source: str, target: str) -> list[str] | None:
+    """Read a `target: prereq prereq` rule line, expanding `$(VAR)` refs."""
+    joined = _join_continuations(source)
+    matches = list(
+        re.finditer(rf"^{re.escape(target)}::?\s*(.*)$", joined, flags=re.MULTILINE)
+    )
+    if len(matches) != 1:
+        return None
+    match = matches[0]
+    if match.group(0).startswith(f"{target}::"):
+        return None
+    expanded: list[str] = []
+    for token in match.group(1).split():
+        ref = re.fullmatch(r"\$\((\w+)\)", token)
+        if ref is None:
+            expanded.append(token)
+            continue
+        expanded.extend(_make_list(source, ref.group(1)) or [])
+    return expanded
+
+
+def _name_defined(source: str, name: str) -> bool:
+    """Whether a line starts with `name` at all, regardless of whether the
+    rest of that line matches the shape this file knows how to parse.
+
+    Distinguishes "this was never defined here" (nothing to protect, skip
+    as always) from "it was defined and got reformatted into something this
+    gate can no longer read" (a silent, permanent erosion of protection
+    worth failing on). `(?![\\w-])` rather than `\\b` so `name="ci"` does not
+    match a `ci-hosted:` line, and a `name` ending in a non-word character
+    like `:` still requires a real boundary after it.
+    """
+    return (
+        re.search(rf"^\s*{re.escape(name)}(?![\w-])", source, flags=re.MULTILINE)
+        is not None
+    )
+
+
+def _gate_topology_policy_reset(base: str, failures: list[str]) -> bool:
+    """Return whether this change deliberately resets gate topology.
+
+    Independent of COVERAGE_POLICY_VERSION: a reviewed threshold reset says
+    nothing about whether a gate itself may be dropped.
+    """
+    base_source = _read_base(base, RATCHET_GATE)
+    if base_source is None:
+        return False
+    now_source = Path(RATCHET_GATE).read_text(encoding="utf-8")
+    was = _constant(base_source, "GATE_TOPOLOGY_POLICY_VERSION") or 1
+    now = _constant(now_source, "GATE_TOPOLOGY_POLICY_VERSION") or 1
+    if now < was:
+        failures.append(f"GATE_TOPOLOGY_POLICY_VERSION lowered {was:g} -> {now:g}.")
+        return False
+    if now > was + 1:
+        failures.append(
+            f"GATE_TOPOLOGY_POLICY_VERSION jumped {was:g} -> {now:g}; advance it "
+            "one reviewed policy revision at a time."
+        )
+        return False
+    return now == was + 1
+
+
+def _check_gate_topology(base: str, failures: list[str], *, policy_reset: bool) -> None:
+    """CI_GATES, and the VERIFY_* lists it expands, may only grow.
+
+    A gate dropped straight from CI_GATES and a gate dropped from a VERIFY_*
+    list it references both surface here, because CI_GATES is expanded
+    recursively -- editing both places to hide a deletion still leaves the
+    expanded set smaller than the base branch's.
+    """
+    base_source = _read_base(base, MAKEFILE)
+    if base_source is None:
+        return
+    was = _make_list(base_source, "CI_GATES")
+    if was is None:
+        # A base branch that never defined CI_GATES has nothing to protect
+        # here -- skip as always. One that defines it in a shape this file's
+        # regex cannot read is the reformat that would let a narrowed set
+        # through unnoticed forever, so that case fails instead, unless it
+        # is itself the reviewed, version-bumped change.
+        if _name_defined(base_source, "CI_GATES") and not policy_reset:
+            failures.append(
+                "CI_GATES on the base branch could not be resolved to a "
+                "single unambiguous value -- either it or a VERIFY_* "
+                "variable it expands does not match the `NAME := val val` "
+                "shape this gate parses, or is assigned more than once; "
+                "update the parser and advance GATE_TOPOLOGY_POLICY_VERSION "
+                "if this reformat is deliberate."
+            )
+        return
+    if policy_reset:
+        return
+    now = _make_list(Path(MAKEFILE).read_text(encoding="utf-8"), "CI_GATES") or []
+    dropped = [gate for gate in was if gate not in now]
+    if dropped:
+        failures.append(f"CI_GATES dropped required gate(s): {dropped}.")
+
+
+def _check_make_chains(base: str, failures: list[str], *, policy_reset: bool) -> None:
+    """The prerequisite chains that wire gates into `ci`/`ci-hosted` may only grow.
+
+    `_make_prereqs` matches any line starting with `target:`, whatever
+    follows -- there is no reformat of an existing rule's right-hand side
+    that would make it return None, only a rule that never existed on the
+    base branch. So a None here has one cause worth handling: skip, the
+    same as every other threshold in this file skips a check for code that
+    was not there yet on `base`.
+    """
+    base_source = _read_base(base, MAKEFILE)
+    if base_source is None:
+        return
+    now_source = Path(MAKEFILE).read_text(encoding="utf-8")
+    for target in TOPOLOGY_TARGETS:
+        was = _make_prereqs(base_source, target)
+        if was is None or policy_reset:
+            continue
+        now = _make_prereqs(now_source, target) or []
+        dropped = [item for item in was if item not in now]
+        if dropped:
+            failures.append(f"{target}: prerequisite(s) dropped: {dropped}.")
+
+
+def _ci_job_names(source: str) -> set[str]:
+    jobs_section = source.partition("\njobs:\n")[2]
+    return set(
+        re.findall(r"^  ([A-Za-z_][A-Za-z0-9_-]*):", jobs_section, flags=re.MULTILINE)
+    )
+
+
+def _check_hosted_jobs(base: str, failures: list[str], *, policy_reset: bool) -> None:
+    base_source = _read_base(base, CI_WORKFLOW)
+    if base_source is None or policy_reset:
+        return
+    now_source = Path(CI_WORKFLOW).read_text(encoding="utf-8")
+    dropped = _ci_job_names(base_source) - _ci_job_names(now_source)
+    if dropped:
+        failures.append(f"CI workflow job(s) deleted: {sorted(dropped)}.")
+
+
+def _job_block(source: str, job: str) -> str | None:
+    """Return a top-level job's body, up to (not including) the next job."""
+    marker = f"\n  {job}:\n"
+    start = source.find(marker)
+    if start == -1:
+        return None
+    body = source[start + len(marker) :]
+    next_job = re.search(r"^  [A-Za-z_][A-Za-z0-9_-]*:", body, flags=re.MULTILINE)
+    return body[: next_job.start()] if next_job else body
+
+
+def _quality_gate_needs(source: str) -> set[str] | None:
+    """quality-gate's own `needs:`, not the first flow-style `needs:` in the
+    rest of the file. Deleting quality-gate's list while adding an unrelated
+    `needs: [...]` to a later job must not be read as quality-gate's own --
+    that reformats the exploit into an outright deletion, not a survival.
+    """
+    block = _job_block(source, "quality-gate")
+    if block is None:
+        return None
+    match = re.search(r"^\s*needs:\s*\[([^\]]*)\]\s*$", block, flags=re.MULTILINE)
+    if match is None:
+        return None
+    return {name.strip() for name in match.group(1).split(",") if name.strip()}
+
+
+def _check_quality_gate_needs(
+    base: str, failures: list[str], *, policy_reset: bool
+) -> None:
+    """quality-gate's `needs:` list is what makes a lane block the required
+    check; a lane that still runs but drops out of `needs:` stops mattering."""
+    base_source = _read_base(base, CI_WORKFLOW)
+    if base_source is None:
+        return
+    was = _quality_gate_needs(base_source)
+    if was is None:
+        # A base branch with no quality-gate job, or one with no needs: line
+        # inside it, has nothing here to protect -- skip. One where needs:
+        # is present but not in the single-line flow-style shape this gate
+        # parses (e.g. reformatted to a multi-line block) fails instead,
+        # unless that reformat is itself the reviewed, version-bumped change.
+        block = _job_block(base_source, "quality-gate") or ""
+        if _name_defined(block, "needs:") and not policy_reset:
+            failures.append(
+                "quality-gate's needs: on the base branch does not match "
+                "the single-line `needs: [a, b]` shape this gate parses; "
+                "update the parser and advance GATE_TOPOLOGY_POLICY_VERSION "
+                "if this reformat is deliberate."
+            )
+        return
+    if policy_reset:
+        return
+    now = _quality_gate_needs(Path(CI_WORKFLOW).read_text(encoding="utf-8")) or set()
+    dropped = was - now
+    if dropped:
+        failures.append(
+            f"quality-gate needs narrowed; no longer required: {sorted(dropped)}."
+        )
+
+
+def _check_ci_diff_coverage_step(
+    base: str, failures: list[str], *, policy_reset: bool
+) -> None:
+    """The coverage job must keep an actual `run: make diff-coverage` step.
+
+    Scoped to a `run:` line inside the coverage job block, not a whole-file
+    substring: a comment mentioning the command, or the step surviving in a
+    different job, must not satisfy this.
+    """
+    base_source = _read_base(base, CI_WORKFLOW)
+    if base_source is None:
+        return
+    base_block = _job_block(base_source, "coverage")
+    if base_block is None or not re.search(
+        r"^\s*run:\s*make diff-coverage[^|;&]*$", base_block, flags=re.MULTILINE
+    ):
+        return
+    if policy_reset:
+        return
+    now_source = Path(CI_WORKFLOW).read_text(encoding="utf-8")
+    now_block = _job_block(now_source, "coverage")
+    if now_block is None or not re.search(
+        r"^\s*run:\s*make diff-coverage[^|;&]*$", now_block, flags=re.MULTILINE
+    ):
+        failures.append(
+            "the diff-coverage step was removed from the coverage job in "
+            "ci.yml; changed lines would no longer need tests in CI."
+        )
+
+
+def _has_gitleaks_step(block: str) -> bool:
+    """A real `uses: gitleaks/gitleaks-action@...` step, not a mention of one.
+
+    A commented-out `# uses: gitleaks/...` line kept the substring form of
+    this check green while nothing scanned for secrets.
+    """
+    return (
+        re.search(
+            r"^\s*(?:-\s*)?uses:\s*gitleaks/gitleaks-action@",
+            block,
+            flags=re.MULTILINE,
+        )
+        is not None
+    )
+
+
+def _check_ci_secret_scan_step(
+    base: str, failures: list[str], *, policy_reset: bool
+) -> None:
+    """The secret-scan job must keep its Gitleaks step.
+
+    Scoped to the secret-scan job block: a gitleaks-action reference
+    surviving in an unrelated job, or as a comment, must not satisfy this.
+    """
+    base_source = _read_base(base, CI_WORKFLOW)
+    if base_source is None:
+        return
+    base_block = _job_block(base_source, "secret-scan")
+    if base_block is None or not _has_gitleaks_step(base_block):
+        return
+    if policy_reset:
+        return
+    now_source = Path(CI_WORKFLOW).read_text(encoding="utf-8")
+    now_block = _job_block(now_source, "secret-scan")
+    if now_block is None or not _has_gitleaks_step(now_block):
+        failures.append(
+            "the Gitleaks step was removed from the secret-scan job in "
+            "ci.yml; nothing would scan for leaked secrets."
+        )
+
+
+def _quality_gate_success_count(source: str) -> int | None:
+    """How many successful lanes quality-gate's assertion step demands.
+
+    None when the step is gone or is no longer a `test "$LANE_RESULTS" = ...`
+    comparison against a run of `success` words, so rewriting it to anything
+    else -- `run: true`, a script, a comment -- reads as asserting nothing.
+    """
+    block = _job_block(source, "quality-gate")
+    if block is None:
+        return None
+    match = re.search(
+        r'^\s*run:\s*test\s+"\$LANE_RESULTS"\s*=\s*"([^"]*)"\s*$',
+        block,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        return None
+    words = match.group(1).split()
+    if not words or any(word != "success" for word in words):
+        return None
+    return len(words)
+
+
+def _check_ci_quality_gate_assertion(
+    base: str, failures: list[str], *, policy_reset: bool
+) -> None:
+    """quality-gate must keep asserting that every lane it needs succeeded.
+
+    The `needs:` list alone does not make the aggregate check meaningful:
+    `if: always()` runs the job whatever the lanes did, and only this step
+    turns a failed lane into a failed required check. So the assertion is
+    checked against the `needs:` list as well as against the base -- a lane
+    the assertion does not count is a lane that can fail in silence.
+    """
+    base_source = _read_base(base, CI_WORKFLOW)
+    if base_source is None or _quality_gate_success_count(base_source) is None:
+        return
+    if policy_reset:
+        return
+    now_source = Path(CI_WORKFLOW).read_text(encoding="utf-8")
+    now = _quality_gate_success_count(now_source)
+    if now is None:
+        failures.append(
+            "quality-gate no longer asserts that every lane succeeded; keep "
+            'its `test "$LANE_RESULTS" = "success ..."` step in ci.yml.'
+        )
+        return
+    required = len(_quality_gate_needs(now_source) or set())
+    if now < required:
+        failures.append(
+            f"quality-gate asserts only {now} successful lane(s) but needs "
+            f"{required}; the extra lane(s) could fail without blocking the "
+            "required check."
+        )
+
+
+# The paths every other check reads. Repointing one at a file absent from the
+# base tree makes `_read_base` return None and that whole family of checks
+# skip in silence, so the constants are themselves a guarded threshold.
+GUARDED_PATHS = (
+    "COVERAGE_GATE",
+    "MUTATION_GATE",
+    "PYPROJECT",
+    "MAKEFILE",
+    "SEMGREP_RULES",
+    "CI_WORKFLOW",
+    "RATCHET_GATE",
+)
+
+# Make flags and special targets that turn a failing recipe into a passing
+# build. `.IGNORE:` with no prerequisites applies to every target at once.
+_MAKE_IGNORE_FLAGS = re.compile(
+    r"^\s*MAKEFLAGS\s*\+?=.*(?:\s|^)(?:-i|-k|--ignore-errors|--keep-going)\b",
+    re.MULTILINE,
+)
+_MAKE_IGNORE_TARGET = re.compile(r"^\.IGNORE\s*:\s*$", re.MULTILINE)
+
+
+def _check_ratchet_self(base: str, failures: list[str], *, policy_reset: bool) -> None:
+    """The gate's own guarded paths and target list may not quietly narrow."""
+    base_source = _read_base(base, RATCHET_GATE)
+    if base_source is None or policy_reset:
+        return
+    now_source = Path(RATCHET_GATE).read_text(encoding="utf-8")
+    for name in GUARDED_PATHS:
+        was = _constant(base_source, name)
+        now = _constant(now_source, name)
+        if was is not None and was != now:
+            failures.append(
+                f"{name} repointed {was!r} -> {now!r}; the checks reading it "
+                "would compare against a path absent from the base tree."
+            )
+    was_targets = _constant(base_source, "TOPOLOGY_TARGETS") or ()
+    now_targets = _constant(now_source, "TOPOLOGY_TARGETS") or ()
+    dropped = [target for target in was_targets if target not in now_targets]
+    if dropped:
+        failures.append(f"TOPOLOGY_TARGETS dropped: {dropped}.")
+
+
+def _check_make_error_handling(
+    base: str, failures: list[str], *, policy_reset: bool
+) -> None:
+    """`make ci` must keep reporting a failing gate as a failure."""
+    base_source = _read_base(base, MAKEFILE)
+    if base_source is None or policy_reset:
+        return
+    now_source = Path(MAKEFILE).read_text(encoding="utf-8")
+    if _MAKE_IGNORE_TARGET.search(now_source) and not _MAKE_IGNORE_TARGET.search(
+        base_source
+    ):
+        failures.append(
+            "`.IGNORE:` added to the Makefile; every gate's failure would be "
+            "ignored while the gate list stays intact."
+        )
+    if _MAKE_IGNORE_FLAGS.search(now_source) and not _MAKE_IGNORE_FLAGS.search(
+        base_source
+    ):
+        failures.append(
+            "MAKEFLAGS gained an error-ignoring flag (-i/-k); a failing gate "
+            "would no longer fail the build."
+        )
+
+
+def _recipe(source: str, target: str) -> list[str] | None:
+    """A target's recipe lines, in order, without the leading tab."""
+    match = re.search(
+        rf"^{re.escape(target)}:[^\n]*\n((?:\t[^\n]*\n)*)",
+        source,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        return None
+    return [line[1:] for line in match.group(1).splitlines()]
+
+
+def _check_make_recipes(base: str, failures: list[str], *, policy_reset: bool) -> None:
+    """A protected gate's commands may only grow, and may not go advisory.
+
+    A gate whose recipe becomes `@true`, or whose command gains make's `-`
+    ignore-failure prefix, still announces itself and still appears in
+    CI_GATES -- the name survives every topology check while the check it
+    names stops running.
+    """
+    base_source = _read_base(base, MAKEFILE)
+    if base_source is None or policy_reset:
+        return
+    now_source = Path(MAKEFILE).read_text(encoding="utf-8")
+    for gate in _make_list(base_source, "CI_GATES") or []:
+        was = _recipe(base_source, gate)
+        if was is None:
+            continue
+        now = _recipe(now_source, gate)
+        if now is None:
+            failures.append(f"{gate}: recipe deleted.")
+            continue
+        for command in was:
+            if command not in now:
+                failures.append(
+                    f"{gate}: command dropped from its recipe: {command!r}."
+                )
+        for command in now:
+            if command.lstrip().startswith("-") and command not in was:
+                failures.append(
+                    f"{gate}: command made failure-ignoring with make's `-` "
+                    f"prefix: {command!r}."
+                )
+
+
+def _check_make_base_refs(
+    base: str, failures: list[str], *, policy_reset: bool
+) -> None:
+    """The refs every comparison is made against are themselves a threshold.
+
+    Repointing RATCHET_BASE or DIFF_BASE at HEAD compares a branch with
+    itself, which cannot fail; hardcoding a ref into the `ratchet:` recipe
+    does the same while leaving the variable looking untouched.
+    """
+    base_source = _read_base(base, MAKEFILE)
+    if base_source is None or policy_reset:
+        return
+    now_source = Path(MAKEFILE).read_text(encoding="utf-8")
+    for name in ("RATCHET_BASE", "DIFF_BASE"):
+        was = re.search(rf"^{name}\s*\?*=\s*(\S+)\s*$", base_source, re.MULTILINE)
+        now = re.search(rf"^{name}\s*\?*=\s*(\S+)\s*$", now_source, re.MULTILINE)
+        if was is None:
+            continue
+        if now is None or now.group(1) != was.group(1):
+            got = now.group(1) if now else "<removed>"
+            failures.append(
+                f"{name} changed {was.group(1)!r} -> {got!r}; comparisons are "
+                "made against this ref, so it is a threshold too."
+            )
+    for command in _recipe(now_source, "ratchet") or []:
+        if "ratchet_gate.py" in command and "$(RATCHET_BASE)" not in command:
+            failures.append(
+                "the ratchet recipe no longer passes $(RATCHET_BASE); a "
+                f"hardcoded base cannot fail: {command.strip()!r}."
+            )
+
+
+# What a job's steps promise to do. `run:` and `uses:` are the work itself,
+# `if:` decides whether it happens, and a job's `name:` is the identity
+# branch protection matches on -- each can be edited to leave a lane that
+# exists, reports success, and does nothing.
+_JOB_DIRECTIVES = re.compile(
+    r"^\s*(?:-\s*)?(run|uses|if|name):\s*(.+?)\s*$", re.MULTILINE
+)
+
+
+def _job_directives(block: str) -> set[str]:
+    return {f"{key}: {value}" for key, value in _JOB_DIRECTIVES.findall(block)}
+
+
+def _check_ci_job_integrity(
+    base: str, failures: list[str], *, policy_reset: bool
+) -> None:
+    """Every lane must keep doing what it did, not merely keep existing."""
+    base_source = _read_base(base, CI_WORKFLOW)
+    if base_source is None or policy_reset:
+        return
+    now_source = Path(CI_WORKFLOW).read_text(encoding="utf-8")
+    for job in sorted(_ci_job_names(base_source)):
+        base_block = _job_block(base_source, job)
+        now_block = _job_block(now_source, job)
+        if base_block is None:
+            continue
+        if now_block is None:
+            continue
+        dropped = sorted(_job_directives(base_block) - _job_directives(now_block))
+        if dropped:
+            failures.append(f"{job}: job no longer does what it did: {dropped}.")
+        if re.search(
+            r"^\s*continue-on-error:\s*true\s*$", now_block, flags=re.MULTILINE
+        ) and not re.search(
+            r"^\s*continue-on-error:\s*true\s*$", base_block, flags=re.MULTILINE
+        ):
+            failures.append(
+                f"{job}: continue-on-error added; a failing lane would report "
+                "success to the aggregate check."
+            )
+
+
+def _check_ci_triggers(base: str, failures: list[str], *, policy_reset: bool) -> None:
+    """The events that start CI may only grow."""
+    base_source = _read_base(base, CI_WORKFLOW)
+    if base_source is None or policy_reset:
+        return
+    now_source = Path(CI_WORKFLOW).read_text(encoding="utf-8")
+
+    def triggers(source: str) -> set[str]:
+        section = source.partition("\non:\n")[2].partition("\njobs:")[0]
+        return set(re.findall(r"^  ([a-z_]+):", section, flags=re.MULTILINE))
+
+    dropped = triggers(base_source) - triggers(now_source)
+    if dropped:
+        failures.append(f"CI trigger(s) removed: {sorted(dropped)}.")
+
+
 def main(argv: list[str]) -> int:
     base = argv[1] if len(argv) > 1 else "origin/master"
 
@@ -253,6 +914,21 @@ def main(argv: list[str]) -> int:
     _check_pyproject(base, failures, coverage_policy_reset=coverage_policy_reset)
     _check_diff_coverage_floor(base, failures)
     _check_semgrep_rules(base, failures)
+
+    topology_policy_reset = _gate_topology_policy_reset(base, failures)
+    _check_gate_topology(base, failures, policy_reset=topology_policy_reset)
+    _check_make_chains(base, failures, policy_reset=topology_policy_reset)
+    _check_hosted_jobs(base, failures, policy_reset=topology_policy_reset)
+    _check_quality_gate_needs(base, failures, policy_reset=topology_policy_reset)
+    _check_ci_diff_coverage_step(base, failures, policy_reset=topology_policy_reset)
+    _check_ci_secret_scan_step(base, failures, policy_reset=topology_policy_reset)
+    _check_ci_quality_gate_assertion(base, failures, policy_reset=topology_policy_reset)
+    _check_ratchet_self(base, failures, policy_reset=topology_policy_reset)
+    _check_make_error_handling(base, failures, policy_reset=topology_policy_reset)
+    _check_make_recipes(base, failures, policy_reset=topology_policy_reset)
+    _check_make_base_refs(base, failures, policy_reset=topology_policy_reset)
+    _check_ci_job_integrity(base, failures, policy_reset=topology_policy_reset)
+    _check_ci_triggers(base, failures, policy_reset=topology_policy_reset)
 
     for failure in failures:
         print(f"error: {failure}")


### PR DESCRIPTION
Closes #48.

The ratchet guarded numeric thresholds and Semgrep rule IDs, but not the gate set itself: `CI_GATES` and the `ci` dependency graph could be narrowed together and still satisfy the advertised-versus-announced test, which is exactly what the issue describes.

## Topology, as the issue asks

New checks in `tools/ratchet_gate.py`, gated by an independent `GATE_TOPOLOGY_POLICY_VERSION` that a deliberate reset advances by exactly one, mirroring `COVERAGE_POLICY_VERSION`:

- `CI_GATES` membership, expanding `$(VERIFY_*)` recursively so a gate dropped from a nested list surfaces like one dropped directly — this is the "edit both places consistently" hole the issue names;
- the Makefile prerequisite chains wiring gates into `ci` / `ci-hosted`;
- hosted job existence, `quality-gate`'s `needs:`, its every-lane-succeeded assertion, the diff-coverage step, and the Gitleaks step.

`secret-scan` stays out of `quality-gate`'s `needs:` — it is protected as it exists today, since adding it would be a behavior change beyond the issue's "protect existing topology only" boundary.

## Topology alone was not enough

A gate can survive in name while checking nothing, so the same ratchet now also blocks: a recipe emptied or made failure-ignoring (`-` prefix, `.IGNORE`, `-i`/`-k` in `MAKEFLAGS`); a lane whose `run:` / `uses:` / `if:` stops doing what it did; a `continue-on-error:` that reports a red lane green; the required check renamed out from under branch protection; a dropped CI trigger; and `RATCHET_BASE` / `DIFF_BASE` repointed at a ref that makes a comparison incapable of failing.

## The gate guards itself

It is only as good as what it reads. Its guarded path constants and `TOPOLOGY_TARGETS` are ratcheted, and both `_constant` and the Makefile variable readers fail closed on duplicate bindings — make resolves a variable to the last assignment and Python to the last binding, while a first-match reader takes the first. That gap alone let a second `VERIFY_QUICK :=` drop four gates from `make ci` with the ratchet green, and let an added `GATE_TOPOLOGY_POLICY_VERSION = 2` buy a full reset while the reviewed line still read `1`.

Parsing stays regex-only over committed files and never executes issue or agent text.

## Verification

28 planted bypasses each confirmed to exit 1, against the real `Makefile` and `ci.yml` rather than fixtures only; three legitimate-change controls (clean tree, a new gate appended, a new job added) still exit 0 with no version bump. `make ci` passes: all 11 gates, 690 tests, 98.88% coverage.

## Known limits

`_read_base` returning inverted, or `main()` returning 0 on failure, disables the tool from inside. No self-check can defend against arbitrary edits to its own logic — that boundary is code review, not the ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmqF9Cp5qhKw8WkuC3gAjd