### PR TITLE
Fix three defects merged unreviewed in #78 (`--team`)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -176,7 +176,8 @@ metadata are left for the caller to remove with `git worktree remove`.
 Neither `--team` alone nor a bare `NAME` is an error; `delete` with
 **neither** is (exit 2). Teardown takes an exclusive, non-blocking lock on
 the team and refuses (exit 1) if another command is using it; it also exits
-1 if the named team doesn't exist. See
+1 if the named team doesn't exist. It never reads the registry it removes,
+so it still works on a team whose state file has gone bad. See
 [Teams](#teams) below.
 
 ## Teams

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ locking model, and worked examples.
 
 ## State
 
-The entire registry lives in one JSON file:
+Without `--team`, the entire registry lives in one JSON file:
 
 ```json
 {

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -23,7 +23,7 @@ import sys
 import time
 import tomllib
 from collections.abc import Callable, Iterable, Iterator
-from contextlib import AbstractContextManager, contextmanager, nullcontext
+from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
 from pathlib import Path
 from typing import Any, NoReturn, cast
 
@@ -105,6 +105,10 @@ class AgentExistsError(OrchestratorError, ValueError):
 
 class StateError(OrchestratorError):
     """The state file exists but does not hold the structure this code needs."""
+
+
+class TeamBusyError(OrchestratorError):
+    """Teardown asked for a team another command is still holding."""
 
 
 # User-facing failures that must print one line and exit 1, never a traceback.
@@ -627,9 +631,8 @@ def _teardown_team(team: str) -> None:
 
 
 def cmd_delete(orchestrator: Orchestrator, opts: argparse.Namespace) -> None:
-    if opts.team is not None and opts.name is None:
-        _teardown_team(opts.team)
-        return
+    # Always a named agent: `delete --team T` with no name is teardown, and
+    # main() runs that itself, before an Orchestrator exists.
     agent = orchestrator.delete(opts.name)
     print(f"deleted agent '{agent.name}' backend={agent.backend.name}")
 
@@ -1024,6 +1027,34 @@ def _team_lock_path(team_root: Path) -> Path:
     return team_root / ".lock"
 
 
+@contextmanager
+def _team_locked(path: Path, team: str, mode: int) -> Iterator[None]:
+    """Hold the team lock, reporting a lost race as `TeamBusyError`.
+
+    The conversion happens around the acquisition and nothing else. Catching
+    `BlockingIOError` around the whole dispatch instead would claim it for any
+    incidental one raised behind it — a backend's pipe, a write to a
+    non-blocking stdout — and answer "the team is in use" to a caller that
+    never asked for a team at all. That is the mystery `OrchestratorError`'s
+    docstring describes.
+
+    Teardown asks with `LOCK_NB` rather than a blocking `LOCK_EX` because
+    Linux flock has no writer fairness: a queued exclusive waiter is
+    overtaken by every later shared request, so a blocking teardown on a busy
+    team would wait indefinitely. `TeamBusyError` exits 1, not argparse's 2 —
+    a busy resource is not a usage mistake.
+    """
+    with ExitStack() as stack:
+        try:
+            stack.enter_context(_flock(path, mode))
+        except BlockingIOError:
+            raise TeamBusyError(
+                f"team '{team}' is in use by another command; try again "
+                "once it finishes"
+            ) from None
+        yield
+
+
 def _resolve_team(
     opts: argparse.Namespace, teardown: bool
 ) -> AbstractContextManager[None]:
@@ -1089,9 +1120,9 @@ def _resolve_team(
     # LOCK_SH for every team verb but teardown, so concurrent turns in one
     # team don't serialize on each other; LOCK_EX|LOCK_NB for teardown, so a
     # team must not be torn down while a command in it is running, and a
-    # busy team fails fast (flock has no writer fairness — see main()).
+    # busy team fails fast (flock has no writer fairness — see _team_locked).
     mode = fcntl.LOCK_EX | fcntl.LOCK_NB if teardown else fcntl.LOCK_SH
-    return _flock(_team_lock_path(team_root), mode)
+    return _team_locked(_team_lock_path(team_root), team, mode)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -1128,20 +1159,17 @@ def main(argv: list[str] | None = None) -> None:
     try:
         team_lock = _resolve_team(opts, teardown)
         with team_lock:
-            orch = Orchestrator()
             log.debug("cli: dispatching '%s'", opts.verb)
-            VERBS[opts.verb](orch, opts)
-    except BlockingIOError:
-        # Linux flock has no writer fairness — a blocking LOCK_EX here could
-        # wait indefinitely behind a stream of shared locks. Failing fast and
-        # naming the team is the right behavior for a teardown that lost the
-        # race, not exit 2: this is a busy resource, not a usage mistake.
-        print(
-            f"team '{opts.team}' is in use by another command; try again "
-            "once it finishes",
-            file=sys.stderr,
-        )
-        raise SystemExit(1) from None
+            if teardown:
+                # Ahead of Orchestrator(), and not through VERBS: the
+                # constructor parses the registry, and a registry that will
+                # not parse — invalid JSON, a backend this build no longer
+                # has — is exactly what teardown exists to remove. Building
+                # one first left `rm -rf` as the only way to retire a team
+                # whose state file had gone bad.
+                _teardown_team(opts.team)
+            else:
+                VERBS[opts.verb](Orchestrator(), opts)
     except _CLI_ERRORS as exc:
         # KeyError(str) renders as '"message"' — print the payload, not repr.
         message = exc.args[0] if exc.args else str(exc)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+"""Fixtures every test file gets.
+
+Deliberately thin: helpers belong next to the tests that use them. What lives
+here is process-global state the code under test mutates and never restores.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+import orchestrator
+
+
+@pytest.fixture(autouse=True)
+def _restore_own_logger_levels() -> Iterator[None]:
+    """Put this project's logger levels back after every test.
+
+    `_configure_logging` raises them by name for `-v`/`-vv` and nothing ever
+    lowers them again, so a single `main(["-v", ...])` leaves every later
+    test in the same process logging at DEBUG. Tests asserting an exact set
+    of records then fail on records the code was right to emit — and only
+    when pytest-randomly happens to order the two that way, which is exactly
+    the shape of flake that reads as a mutant killed by luck.
+    """
+    saved = {name: logging.getLogger(name).level for name in orchestrator.OWN_LOGGERS}
+    try:
+        yield
+    finally:
+        for name, level in saved.items():
+            logging.getLogger(name).setLevel(level)

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import fcntl
 import json
 import os
@@ -395,6 +396,98 @@ def test_teardown_of_a_team_with_no_agents_ever_created_succeeds(
 
     assert capsys.readouterr().out == "deleted team 't1'\n"
     assert not (teams_dir / "t1" / "agents").exists()
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("invalid json", "not json"),
+        (
+            "unknown backend",
+            '{"owen": {"backend": "retired-backend", "session_id": null}}',
+        ),
+    ],
+)
+def test_teardown_removes_a_registry_it_cannot_parse(
+    label: str,
+    payload: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Teardown must not need the registry it deletes to be readable.
+
+    Constructing an `Orchestrator` first made both of these unrecoverable:
+    the constructor parses the state file, so the one command whose job is
+    to remove a broken registry was the one the broken registry stopped,
+    leaving `rm -rf` as the only way out.
+    """
+    teams_dir = tmp_path / "teams"
+    agents_dir = teams_dir / "t1" / "agents"
+    agents_dir.mkdir(parents=True)
+    (teams_dir / "t1" / "worktree").mkdir()
+    (agents_dir / "orchestrator_state.json").write_text(payload, encoding="utf-8")
+    monkeypatch.setattr(orchestrator, "TEAMS_DIR", teams_dir)
+
+    orchestrator.main(["delete", "--team", "t1"])
+
+    captured = capsys.readouterr()
+    assert captured.out == "deleted team 't1'\n"
+    assert captured.err == ""
+    assert not agents_dir.exists()
+
+
+def _make_blocking_backend() -> type[AgentBackend]:
+    """A backend whose turn fails the way a non-blocking pipe does.
+
+    Not hypothetical: `print`ing a large reply to a stdout someone left
+    O_NONBLOCK raises exactly this, and so can a backend's own pipe.
+    """
+
+    class BlockingBackend(AgentBackend):
+        @property
+        def name(self) -> str:
+            return "blocking"
+
+        def run_turn(
+            self,
+            prompt: str,
+            session_id: str | None,
+            cwd: Path,
+            timeout: int = orchestrator.DEFAULT_TURN_TIMEOUT,
+            schema=None,
+        ) -> TurnResult:
+            raise BlockingIOError(
+                errno.EAGAIN, "write could not complete without blocking"
+            )
+
+    return BlockingBackend
+
+
+@pytest.mark.parametrize("team_argv", [[], ["--team", "t1"]])
+def test_an_incidental_blocking_io_error_is_not_a_busy_team(
+    team_argv: list[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Only the team lock may report that a team is in use.
+
+    Catching `BlockingIOError` around the whole dispatch claimed every other
+    one for the lock — a teamless `talk` died with "team 'None' is in use by
+    another command", exit 1, and the real error was gone.
+    """
+    register_backend("blocking", _make_blocking_backend())
+    teams_dir = tmp_path / "teams"
+    (teams_dir / "t1" / "worktree").mkdir(parents=True)
+    monkeypatch.setattr(orchestrator, "TEAMS_DIR", teams_dir)
+    monkeypatch.setattr(orchestrator, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setattr(orchestrator, "WORKDIR", tmp_path)
+
+    with pytest.raises(BlockingIOError):
+        orchestrator.main(["talk", "a", *team_argv, "-b", "blocking", "-p", "hi"])
+
+    assert "in use by another command" not in capsys.readouterr().err
 
 
 def test_teardown_of_an_unknown_team_exits_1(


### PR DESCRIPTION
#78 was merged with zero reviews. This is that review, plus the fixes.

Every finding below is reproduced against the merged commit `a488fdd`, and every fix ships with a regression test proven to fail without it (`make verify-regression`).

---

## 1. Teardown could not remove a registry it could not read

`main()` constructed an `Orchestrator` — whose constructor parses the state file — before dispatching the verb. `delete --team T` is the one command whose job is to delete that file, so a registry that will not parse made the team unrecoverable except by hand.

Against `a488fdd`:

```
$ printf 'not json' > "$TEAMS/issue-73/agents/orchestrator_state.json"
$ orchestrator delete --team issue-73
.../agents/orchestrator_state.json is not valid JSON: Expecting value: line 1 column 1 (char 0)
exit=1
$ ls "$TEAMS/issue-73/agents"
orchestrator_state.json  orchestrator_state.json.lock      # removed nothing

$ echo '{"owen": {"backend": "retired-backend", "session_id": null}}' > .../orchestrator_state.json
$ orchestrator delete --team issue-73
Unknown backend 'retired-backend'. Available backends: claude, codex, grok, opencode
exit=1
```

The second case is the realistic one: a state file written by a build that had a backend this one does not. `rm -rf` was the only way out — which is precisely what teardown exists to spare the caller.

**Fix.** Teardown dispatches inside the team lock but ahead of `Orchestrator()`, and no longer routes through `VERBS`/`cmd_delete`. Everything else about it is unchanged: still `LOCK_EX | LOCK_NB`, still scoped to `agents/`, still leaves `.lock` and `worktree/` alone.

Verified end-to-end on the corrupted team above:

```
$ orchestrator delete --team issue-73
deleted team 'issue-73'
exit=0
$ find "$TEAMS/issue-73" -maxdepth 1
.../issue-73  .../issue-73/.lock  .../issue-73/worktree
$ git worktree list          # no 'prunable'
```

## 2. `except BlockingIOError` claimed every incidental one for the team lock

The handler wrapped the whole dispatch — `Orchestrator()`, the turn, and the `print` of the reply — not just the lock acquisition. Only the acquisition can mean "the team is busy".

Against `a488fdd`, a **teamless** `talk` whose reply is written to a stdout someone left `O_NONBLOCK`:

```
created agent 'a' backend=big
team 'None' is in use by another command; try again once it finishes
exit code: 1
```

A real `BlockingIOError` from `print(result.reply)`, reported as a lock the caller never took, exit 1, original error discarded. This is the failure mode `OrchestratorError`'s own docstring already warns about:

> Catching the builtins around the whole dispatch swallowed any incidental one raised inside a backend too, and printed it as a bare one-word line with no traceback — turning a real bug into a mystery.

**Fix.** A `_team_locked(path, team, mode)` wrapper converts `BlockingIOError` to a new `TeamBusyError(OrchestratorError)` around `enter_context(_flock(...))` and nothing else. A genuinely lost race produces the identical message and exit 1 (the existing lock-race test passes untouched, and the live two-process race was re-run). Anything else now surfaces as itself:

```
  File "orchestrator/__init__.py", line 588, in cmd_talk
    print(result.reply)
BlockingIOError: [Errno 11] write could not complete without blocking
```

The writer-fairness rationale for `LOCK_NB` moved into `_team_locked`'s docstring, where the flag now lives.

## 3. `docs/configuration.md` still contradicts `--team`

#78 changed README.md's *"The entire registry lives in one JSON file"* to *"Without `--team`, …"* — and left the identical sentence in `docs/configuration.md:53`, a file it edited in the same commit. Fixed the same way.

## 4. #78 routed a latent logging leak into the mutation gate

#78 added `tests/test_cli_surface.py` to `pytest_add_cli_args_test_selection` (`pyproject.toml:125`). That gate runs its selection serially in one process (`-n0`), so `test_cli_surface.py:258-261`'s `main(["-v", …])` / `-vv` calls now share a process with `test_backends.py`'s `_messages(caplog) == []` assertions. `_configure_logging` raises the `orchestrator`/`backends` logger levels by name and nothing ever lowers them, so whether the gate passes depends on the order `pytest-randomly` picked:

```
$ uv run pytest -q -n0 -p no:randomly \
    tests/test_teams.py tests/test_cli_surface.py tests/test_backends.py
FAILED tests/test_backends.py::TestOrchestrator::test_validated_opencode_turn_warns_once_about_cli_schema_enforcement
FAILED tests/test_backends.py::TestOrchestrator::test_schema_warning_is_absent_without_schema_or_for_enforcing_backend
2 failed, 363 passed
```

Same result on `a488fdd`, and on `3656f2a` for the two files alone — the leak predates #78, but before #78 the leaker was not in any gate's selection. A mutation gate that passes on the seed is a mutation score earned by luck.

**Fix.** A new `tests/conftest.py` with one autouse fixture that saves and restores `orchestrator.OWN_LOGGERS`' levels around every test. The subset above now passes.

---

## Regression evidence

Per `AGENTS.md`, each fix has a test that fails without it. With `orchestrator/__init__.py` reverted to `a488fdd`:

```
FAILED tests/test_teams.py::test_teardown_removes_a_registry_it_cannot_parse[invalid json-not json]
FAILED tests/test_teams.py::test_teardown_removes_a_registry_it_cannot_parse[unknown backend-...]
FAILED tests/test_teams.py::test_an_incidental_blocking_io_error_is_not_a_busy_team[team_argv0]
FAILED tests/test_teams.py::test_an_incidental_blocking_io_error_is_not_a_busy_team[team_argv1]
4 failed
```

All four pass with it. Finding 4's evidence is the subset command above, red without `tests/conftest.py` and green with it.

## What the review checked and found correct

Not everything was broken — for the record, re-verified against the merged code on a scratch clone:

- V1–V5 all exit 2 and leave the filesystem exactly as they found it, including `a/b`, `..`, `.` and `""`, and `--team` alongside an explicit `AGENTS_ARMY_HOME` / `AGENTS_ARMY_STATE_FILE`.
- `WORKDIR` reaches the backend as the team's worktree; `STATE_FILE` and `SKILLS_DIR` resolve under the team root; an explicit `AGENTS_ARMY_SKILLS` still wins.
- Two teams with the same agent name keep independent registries and session ids.
- Teardown leaves `worktree/` and its git metadata intact — `git worktree list` reports nothing `prunable`.
- A live two-process teardown-versus-`LOCK_SH` race refuses with exit 1 and removes nothing.
- Teamless behavior is byte-identical.
- `pyproject.toml` change: none in this PR (#78's addition of the two test files to the mutation selection is kept — finding 4 fixes the leak it exposed rather than narrowing the selection back).

## How to verify

```sh
uv sync --locked --all-groups
make ci
```

`make ci` passes here: 764 tests, mutation score **98.9%** (2260 killed / 2286, floor 98.0%), all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyS58uM68kPMxL3csAmHsk