### PR TITLE
V3: Doku posts user-facing release notes on the PR

### DIFF
--- a/examples/gabriels_workflow_v3/go.sh
+++ b/examples/gabriels_workflow_v3/go.sh
@@ -154,6 +154,28 @@ for i in {1..10}; do
     private_key: ~/keys/devin-development-specialist.2026-08-13.private-key.pem" &>> devin.log
 done
 
+# The approval is the gate: code the reviewer never signed off gets no release
+# notes, and the loop can also run out of rounds without one.
+gh pr view $pr_url --json labels --jq '.labels[].name' | grep -qx 'reviewer-approves' || exit 3
+
+# Doku writes for whoever will use this, not for whoever reviewed it: what the
+# new version does for them, how to run it, and what will bite them.
+aarmy talk doku --team "$team" -b claude -m opus -e high \
+    -p "You are the documentation writer for the PR '$pr_url'. \
+    Read its description and its diff, and read README.md and docs/ to see how the project describes itself today. \
+    Post one comment on the PR telling a user of this project what this version changes for them. \
+    Write plain, non-technical English: short sentences, no jargon, no file paths, no internal design talk. \
+    Cover what is new or different, how to use it with a copy-pasteable command and a real example, \
+    what they must change on their side to keep working - renamed flags, new defaults, removed behaviour - \
+    and anything else that would surprise them. \
+    Every claim comes from the diff. Do not describe behaviour you did not see in the code, \
+    and if the change is invisible to users say so in one line instead of inventing detail. \
+    Change no files, review nothing, approve nothing - the comment is the whole deliverable. \
+    Post as the github app: \
+    app_id: 4577311 \
+    private_key: ~/keys/doku-documentation-agent.2026-08-12.private-key.pem" &> doku.log
+
+
 # clean up
 
 aarmy delete --team "$team"


### PR DESCRIPTION
## What

Adds a Doku stage to `examples/gabriels_workflow_v3/go.sh`, after the review loop and before cleanup.

Once the reviewer approves, a fresh `doku` agent reads the PR description, its diff, and the README/docs, then posts **one** PR comment written for a user of the tool rather than for a reviewer:

- what is new or different
- how to use it, with a copy-pasteable command and a real example
- what they must change on their side (renamed flags, new defaults, removed behaviour)
- anything else that would surprise them

The prompt holds it to the diff: no behaviour it did not see in the code, and "invisible to users" is a valid one-line answer instead of invented detail. It changes no files, reviews nothing and approves nothing.

Posts as **Doku, Documentation Agent** (`app_id: 4577311`).

## Why

The workflow ended at the reviewer's approval, so the only account of a change was the PR description and the review thread — both written in developer terms. Whoever actually uses the tool got nothing.

## Notes

- The `reviewer-approves` label gates the stage (`exit 3`), so code the reviewer never signed off gets no release notes, and a review loop that runs out of rounds is not mistaken for an approval.
- That `exit 3` skips the cleanup block, matching the existing `exit 1` / `exit 2` gates in the same script.
- `bash -n go.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)