### PR TITLE
Fix six driver defects the #77 run exposed

### DIFF
--- a/examples/gabriels_workflow_v3/go.sh
+++ b/examples/gabriels_workflow_v3/go.sh
@@ -11,7 +11,11 @@ export issue_url
 
 issue_number=${issue_url##*/}
 team="issue-$issue_number"
-export AGENTS_ARMY_TEAMS_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/gdw-v3"
+# Outside the repository, not under .git/. Nested, the driver's own checkout is
+# a parent directory of the agents' cwd, and an agent that wanders up into it
+# is editing the code this script is running from, mid-run: the #80 run had
+# devin editing seven files there and finding the live run's logs and state.
+export AGENTS_ARMY_TEAMS_DIR="$HOME/.agents-army/gdw-v3"
 
 git fetch origin --quiet
 git worktree prune
@@ -39,7 +43,7 @@ aarmy talk owen --team "$team" -b claude -m opus -e high -v \
 
 
 envsubst < spectacle.prompt.tmpl > spectacle.prompt
-aarmy talk spectacle --team "$team" -b claude -m opus -e high --prompt-file spectacle.prompt &> spectacle.log
+aarmy talk spectacle --team "$team" -b claude -m opus -e high -v --prompt-file spectacle.prompt &> spectacle.log
 
 
 # Both agents stop by labelling the issue. Wake whoever has not labelled yet,
@@ -53,8 +57,8 @@ for i in {1..10}; do
 
     [ $owen_done = 0 ] && [ $spectacle_done = 0 ] && break
 
-    [ $owen_done = 0 ] || aarmy talk owen --team "$team" -p 'There are new comments. Read the issue and continue. Label the issue when you have nothing to add.' &>> owen.log
-    [ $spectacle_done = 0 ] || aarmy talk spectacle --team "$team" -p 'There are new comments. Read the issue and continue. Label the issue when you have nothing to add.' &>> spectacle.log
+    [ $owen_done = 0 ] || aarmy talk owen --team "$team" -v -p 'There are new comments. Read the issue and continue. Label the issue when you have nothing to add.' &>> owen.log
+    [ $spectacle_done = 0 ] || aarmy talk spectacle --team "$team" -v -p 'There are new comments. Read the issue and continue. Label the issue when you have nothing to add.' &>> spectacle.log
 done
 
 # Only two happy labels mean the issue converged. A blocked label, or a missing
@@ -75,7 +79,7 @@ git -C "$AGENTS_ARMY_TEAMS_DIR/$team/worktree" clean -qfd
 
 # The draft PR description is the whole handoff: the developer implements from
 # it and never opens the issue, so nothing may be left implicit or unresolved.
-aarmy talk spectacle --team "$team" -p "\
+aarmy talk spectacle --team "$team" -v -p "\
     The issue '$issue_url' has converged. Open a draft PR against the default branch and write its description. \
     Change no files - an empty commit on a new branch is all the PR needs to exist. The description is the deliverable. \
     Link the PR to the issue, but write the description so it stands completely on its own: \
@@ -103,7 +107,7 @@ export pr_url=$(gh pr list --draft --limit 50 --json url,body \
 git -C "$AGENTS_ARMY_TEAMS_DIR/$team/worktree" reset -q --hard
 git -C "$AGENTS_ARMY_TEAMS_DIR/$team/worktree" clean -qfd
 
-aarmy talk devin --team "$team" --timeout 10800 -b claude -m sonnet -e high \
+aarmy talk devin --team "$team" -v --timeout 10800 -b claude -m sonnet -e high \
     -s implement,tdd,code-review-and-quality \
     -p "\
     You are a lead software engineer. \
@@ -112,8 +116,8 @@ aarmy talk devin --team "$team" --timeout 10800 -b claude -m sonnet -e high \
     Good quality and good design practices are paramount. \
     The PR URL is: '$pr_url' use gh cli and git to implement its description. \
     The description is the whole spec. Do not read the issue it links to, or any issue comments. \
-    It is a draft PR with an empty commit - push your implementation to its branch, but leave as draft for now. \
-    Monitor it for comments. A reviewr will give feedback,
+    It is a draft PR with an empty commit - push your implementation to its branch, \
+    but leave as draft for now. A reviewr will give feedback, \
     you have the choice to accept or pushback, but always do justify your decision with \
     code facts and using the skills provided.
     You goals is to converge to a solution that satisfies the PR description and that is Okay \
@@ -126,7 +130,7 @@ aarmy talk devin --team "$team" --timeout 10800 -b claude -m sonnet -e high \
 # line. talk blocks on his lock, so a nudge sent mid-turn just waits its turn.
 for i in {1..5}; do
 
-    aarmy talk devin --team "$team" --timeout 10800 -s code-review-and-quality \
+    aarmy talk devin --team "$team" -v --timeout 10800 -s code-review-and-quality \
     -p "Review your own diff across the five axes first. \
     Then: is the code something you are proud of, a solution you stand behind? \
     Judge that against your own standard, not the skill's 'improves code health' bar. \
@@ -142,14 +146,22 @@ done
 # app, which is the app that opened the PR, and GitHub will not let an account
 # approve its own PR - so the label is the approval, not a review verdict.
 # Review first, then check, so devin is not nudged after an approval.
+# --timeout matches devin's: a review that runs `make ci` costs what building
+# it did, and the default hour cuts the turn off mid-gate.
+head=$(gh pr view $pr_url --json headRefOid --jq .headRefOid)
+
 for i in {1..10}; do
 
-    aarmy talk code-reviewer --team "$team" -b claude -m opus -e high -s code-review-and-quality \
+    aarmy talk code-reviewer --team "$team" -v --timeout 10800 -b claude -m opus -e high -s code-review-and-quality \
     -p "You are the code reviewer for the PR '$pr_url'. \
     Its description is the spec - review the diff against it, and against the five axes. \
     Every finding cites something re-checkable: a path and line, a command and its output, an API response. \
     Say which findings block merging and which are optional. \
     Do not change any code yourself - the developer fixes, you review. \
+    The eleven gates already ran on this commit in CI, in parallel and for free: read their result with \
+    'gh pr checks $pr_url' and 'gh run view <run-id> --log-failed' rather than re-running 'make ci' here. \
+    Run locally only the experiment a finding needs - revert one token and run that test, reproduce the race - \
+    never the whole sweep to confirm what CI has already confirmed. \
     Where the developer pushed back, weigh the argument on its code facts and concede plainly when it is right. \
     otherwise push back with code facts and continue the review. \
     When nothing left blocks merging, and nite are solved, add the label 'reviewer-approves' to the PR, \
@@ -160,14 +172,24 @@ for i in {1..10}; do
 
     gh pr view $pr_url --json labels --jq '.labels[].name' | grep -qx 'reviewer-approves' && break
 
-    aarmy talk devin --team "$team" --timeout 10800 -s implement,tdd \
-    -p "There is new review feedback on '$pr_url'. \
-    Read the review comment and answer it: fix it, or push back with code facts. \
-    Reply saying which you did and why. \
-    Commit and push your fixes to the PR branch. \
-    Post as the github app: \
-    app_id: 4579193 \
-    private_key: ~/keys/devin-development-specialist.2026-08-13.private-key.pem" &>> devin.log
+    # Nudge until the branch actually moves. A turn can end with the work
+    # uncommitted - devin started `make ci` in the background and returned
+    # waiting for a notification a one-shot turn can never deliver, twice in
+    # the #77 run - and the reviewer would then spend a full opus turn
+    # re-reading a commit it has already reviewed.
+    for j in {1..3}; do
+        aarmy talk devin --team "$team" -v --timeout 10800 -s implement,tdd \
+        -p "There is new review feedback on '$pr_url'. \
+        Read the review comment and answer it: fix it, or push back with code facts. \
+        Reply saying which you did and why. \
+        Commit and push your fixes to the PR branch. \
+        Post as the github app: \
+        app_id: 4579193 \
+        private_key: ~/keys/devin-development-specialist.2026-08-13.private-key.pem" &>> devin.log
+
+        new_head=$(gh pr view $pr_url --json headRefOid --jq .headRefOid)
+        [ "$new_head" != "$head" ] && head=$new_head && break
+    done
 done
 
 # The approval is the gate: code the reviewer never signed off gets no release
@@ -176,7 +198,7 @@ gh pr view $pr_url --json labels --jq '.labels[].name' | grep -qx 'reviewer-appr
 
 # Doku writes for whoever will use this, not for whoever reviewed it: what the
 # new version does for them, how to run it, and what will bite them.
-aarmy talk doku --team "$team" -b claude -m opus -e high \
+aarmy talk doku --team "$team" -v -b claude -m opus -e high \
     -p "You are the documentation writer for the PR '$pr_url'. \
     Read its description and its diff, and read README.md and docs/ to see how the project describes itself today. \
     Post one comment on the PR telling a user of this project what this version changes for them. \
@@ -195,5 +217,5 @@ aarmy talk doku --team "$team" -b claude -m opus -e high \
 # clean up
 
 aarmy delete --team "$team"
-git worktree remove "$AGENTS_ARMY_TEAMS_DIR/$team/worktree"
+git worktree remove --force "$AGENTS_ARMY_TEAMS_DIR/$team/worktree"
 rm -rf "$AGENTS_ARMY_TEAMS_DIR/$team"

--- a/examples/gabriels_workflow_v3/go.sh
+++ b/examples/gabriels_workflow_v3/go.sh
@@ -158,10 +158,8 @@ for i in {1..10}; do
     Every finding cites something re-checkable: a path and line, a command and its output, an API response. \
     Say which findings block merging and which are optional. \
     Do not change any code yourself - the developer fixes, you review. \
-    The eleven gates already ran on this commit in CI, in parallel and for free: read their result with \
-    'gh pr checks $pr_url' and 'gh run view <run-id> --log-failed' rather than re-running 'make ci' here. \
-    Run locally only the experiment a finding needs - revert one token and run that test, reproduce the race - \
-    never the whole sweep to confirm what CI has already confirmed. \
+    Verify with 'make ci' here - the local run is far quicker than the same gates on GitHub, \
+    so check the code yourself rather than waiting on the remote checks. \
     Where the developer pushed back, weigh the argument on its code facts and concede plainly when it is right. \
     otherwise push back with code facts and continue the review. \
     When nothing left blocks merging, and nite are solved, add the label 'reviewer-approves' to the PR, \


### PR DESCRIPTION
Six changes to `examples/gabriels_workflow_v3/go.sh`. Every one of them is something the
issue #77 run actually did wrong — measured, not speculated. No behaviour is changed for
any agent's reach or permissions; this is driver hygiene.

## 1. The team directory moves out of `.git/`

```diff
-export AGENTS_ARMY_TEAMS_DIR="$(git rev-parse --path-format=absolute --git-common-dir)/gdw-v3"
+export AGENTS_ARMY_TEAMS_DIR="$HOME/.agents-army/gdw-v3"
```

Nested under `.git/`, the driver's own checkout is a parent directory of every agent's
cwd, so the CLI walks up into it for `AGENTS.md` and it becomes a familiar place to edit.
In the #80 run devin did exactly that, in his own words:

> "partway through I mistakenly ran a batch of `Edit` calls against the main repo checkout
> … caught it via `git status`, reverted those 7 files there without touching the unrelated
> live-run state I found alongside them (`go.sh` edits, run logs from what looks like
> another in-progress GDW run)"

That is the script editing itself mid-run. This is not containment — an agent can still
`cd` anywhere — it removes the accident, not the capability.

## 2. Devin is no longer asked to monitor something he cannot watch

```diff
-    Monitor it for comments. A reviewr will give feedback,
+    but leave as draft for now. A reviewr will give feedback, \
```

A turn is one non-interactive `claude --print` process that ends the moment it returns a
reply. Devin cannot watch a PR; the driver's `for i in {1..10}` loop is the monitor, and
he does not know it exists. He closed his first #77 turn with:

> "Since I'm not running under `/loop`, I won't have an automatic way to notice new
> comments arriving later in this session — if you want me to poll automatically, say the word"

## 3. The reviewer is only paid once the branch has moved

```bash
head=$(gh pr view $pr_url --json headRefOid --jq .headRefOid)
...
    for j in {1..3}; do
        aarmy talk devin ...
        new_head=$(gh pr view $pr_url --json headRefOid --jq .headRefOid)
        [ "$new_head" != "$head" ] && head=$new_head && break
    done
```

Twice in the #77 run devin ended a turn with the work uncommitted — he started `make ci`
in the background and returned waiting for a notification a one-shot turn can never
deliver:

```
09:38  turn finished in 803.5s  ->  "I'll wait for the make ci background task notification
                                     before proceeding to commit, push, and reply."
10:00  turn finished in 404.4s  ->  "I'll wait for `make ci` to complete before committing,
                                     pushing, and posting the reply."
```

1208 seconds, nothing pushed. The driver then handed an unchanged PR to the reviewer
anyway: rounds 2 and 3 both opened on `7767fdd`, costing 915s and 1915s of opus. This gate
would have skipped both.

## 4. The reviewer verifies locally and does not wait on the remote checks

The reviewer had no instruction either way, so it was free to block on GitHub's checks —
the #80 reviewer did exactly that, confirming the six jobs by head SHA. The local `make ci`
returns in seconds against minutes for the remote run, so waiting on the remote trades a
fast signal for a slow one. The prompt now says to verify here and not block on the checks.

It deliberately names no gate count: any number in prompt text goes stale the first time a
gate is added or removed.

*(An earlier revision of this PR said the opposite — read CI, skip the local run — on the
theory that round 3's 32 minutes were `make ci`. Review feedback corrected it: that turn's
time was the reviewer's own experiments, a timing harness and per-test pytest runs, not the
gate suite. Conceded and reversed in 69f4065.)*

## 5. Every turn logs its duration

`-v` was on owen's first call only, so the other four agents and every follow-up turn
logged nothing. At the default WARNING level neither `turn finished in 404.7s` nor
`exited 0 after 404.7s` exists, and "did it time out or just take a while" is not
answerable from the log. Stops at one `-v`; `-vv` would dump every full prompt and reply.

## 6. Two smaller ones

- The reviewer gets devin's `--timeout 10800`. It runs `make ci`, mutation testing
  included; round 3 took 1915s, over half the 3600s default, and a longer one would have
  been cut off mid-gate.
- `git worktree remove --force` at teardown. A finished checkout carries a `.venv` and
  build output, and plain `remove` refuses a tree that is not clean.

## Verification

`bash -n examples/gabriels_workflow_v3/go.sh` passes. The script is not covered by the
Python gates and this diff touches nothing they read; CI on this PR is the check.

The changes were exercised live during the #77 run: the correction in §3 was injected by
hand as a one-off turn and took devin from two dead turns to a clean push in 399s, with
`make ci` green and the mutation score up from 98.1% to 98.6%.
