### PR TITLE
gdw v5: Python driver spec — implement flow.md

### DIFF
--- a/examples/gabriels_workflow_v5/README.md
+++ b/examples/gabriels_workflow_v5/README.md
@@ -1,0 +1,90 @@
+# gdw v5 — implementation brief
+
+You are implementing this workflow. The specification is [flow.md](flow.md):
+implement that diagram, exactly, as a single Python driver named `go.py` in
+this directory. Every agent box in the diagram maps to one prompt file in
+[prompts/](prompts/); the driver renders the prompt and delivers it with one
+`uv run orchestrator talk` call. Do not invent phases, checks, or options the
+diagram does not show. Where this brief and the diagram disagree, the diagram
+wins.
+
+## What the driver does
+
+One command, `python go.py <issue-url>` (or `./go.py`), two behaviors decided
+by the issue's labels — the router at the top of the diagram:
+
+- **Planning**: BFS over the issue and any children owen creates (parsed from
+  the `CHILDREN: #a #b` line ending his split comment), debating every leaf to
+  convergence and posting doku's brief, then a doku tree summary on the root
+  if anything split, then exiting. Cap: 12 issues per run, exit 9 beyond it.
+- **Build**: one converged leaf per invocation — reuse or open the draft PR,
+  devin implements and self-reviews, the driver runs `make ci` itself, at most
+  three review rounds, doku's user note, cleanup.
+
+The primer: planning starts by creating one role-neutral agent whose only turn
+is to study the repository, then uses `uv run orchestrator fork <src> <dst>`
+to give each issue's owen, spectacle, and doku a fresh fork of that session.
+Forks are deleted after their issue. The fork verb exists in this repository —
+read its docs and `--help` before use. If fork is unavailable at runtime, fall
+back to fresh agents per issue and print that the fallback is in effect.
+
+## Operational contracts (carried over from v4, all load-bearing)
+
+- Refuse to start on a dirty checkout (exit 4).
+- Per issue: a fresh team and a fresh worktree from `origin/master`; delete
+  any stale team and worktree from a dead run before the first talk.
+- Run-state vs record: teams and worktrees die with the run; logs go to
+  `~/.agents-army/<repo>/gdw-v5/logs/issue-N/<timestamp>/` — one file per
+  agent, `ci-N.log` for the driver's CI runs — and are never deleted.
+- Prompts are rendered from `prompts/*.md` substituting ONLY these variables:
+  `$issue_url`, `$pr_url`, `$ci_head`, `$ci_log` (use `string.Template`; do
+  not substitute anything else — the prose contains other dollar signs).
+- The first talk to an agent carries its backend flags
+  (`-b claude -m opus -e <effort>`: owen/doku medium, spectacle/devin low,
+  code-reviewer high); later talks resume the session and must not re-send
+  them. Devin's first build talk also carries
+  `-s implement,tdd,code-review-and-quality`; the reviewer's first talk
+  carries `-s code-review-and-quality`; skills are never re-sent.
+- Before relying on devin's work, verify he committed and pushed: clean
+  worktree AND local HEAD == the PR's `headRefOid` (exit 8 otherwise).
+- A failed `make ci` gets exactly one devin repair pass, then one re-run.
+- A PR still in draft after the self-review is a deliberate stop (exit 6):
+  devin found a false assumption and commented on the PR. Do not retry.
+- Find the PR with `gh pr list --draft` filtering bodies for the issue
+  reference; poll up to 6 × 5 s (read-after-write lag). Never create a second
+  PR when one exists.
+- Exit codes: the exact table at the bottom of flow.md.
+
+## Coding rules (as binding as the diagram)
+
+The file must be easy to follow with the eyes, top to bottom, and a reader
+should be able to predict what the terminal prints. Concretely:
+
+**Allowed, and nothing more:**
+- Three tiny helpers, each under ~8 lines: `sh()` (run a command, return
+  stdout, raise on failure), `talk()` (one agent turn: render prompt, invoke
+  the orchestrator, append to the agent's log), `prompt()` (read a prompt
+  file, substitute the explicit variable list).
+- Plain data: lists, dicts, sets. At most one frozen dataclass with fields
+  only, if bare dicts would need comments to explain their keys.
+- Functions named for the diagram's boxes, with the top-to-bottom story at
+  the bottom of the file. Reading order = execution order = the diagram.
+- Exceptions as the error model: let failures crash with the traceback.
+  `try/except` only where the flow genuinely branches on failure (the CI
+  repair pass; the fork-unavailable fallback).
+
+**Banned, permanently:**
+- Classes with behavior, inheritance, or interfaces of any kind.
+- async, threads, or any concurrency — the ordering is the design.
+- CLI frameworks, config objects, YAML: one positional argument from
+  `sys.argv`, constants at the top of the file.
+- Logging frameworks, retry decorators, wrapper layers around `gh`/`git`:
+  `print()` narrates, subprocess output goes to the log files.
+
+## Definition of done
+
+- `go.py` implements every node, edge, and exit code in flow.md.
+- A dry read of the file against the diagram finds a function per box and no
+  code that the diagram cannot explain.
+- `python -m py_compile go.py` passes; the driver runs against a test issue
+  through planning, and against a converged issue through build.

--- a/examples/gabriels_workflow_v5/flow.md
+++ b/examples/gabriels_workflow_v5/flow.md
@@ -1,0 +1,73 @@
+# gdw v5 flow — plan the whole tree with primer forks, then build one leaf per call
+
+This diagram is the specification: [README.md](README.md) tells the
+implementing agent how to turn it into `go.py`. Every agent box's prompt is
+the matching file in [prompts/](prompts/). The issue's labels are the state:
+calling the driver is always safe and always does the right next thing.
+
+```mermaid
+flowchart TD
+    START(["go.py + issue URL"]) --> ROUTE{"Labels?"}
+    ROUTE -- "blocked" --> RB(["exit 1 — resolve evidence first"])
+    ROUTE -- "owens-is-happy +<br>spectacle-is-happy" --> BUILD0
+    ROUTE -- "anything else" --> PRIME
+
+    subgraph PLAN["Invocation A — planning (recursive, then dies)"]
+        PRIME["Prime once per run:<br>one role-neutral session reads the repo"]
+        PQ["Queue = [issue]<br>cap: 12 issues per run"]
+        NEXT{"Next issue<br>from queue"}
+        TRI["fork primer → owen: triage<br>(proceed / reshape / reject / split)"]
+        SPLITN["Children from the CHILDREN: line<br>queued in build order<br>(their forks share the same primer)"]
+        DEB["fork primer → spectacle:<br>critique / concur-veto →<br>(rebuttal → final decision) if disputed<br>checks routed to wherever correctness is cheapest"]
+        BRIEF["fork primer → doku: decision brief<br>(350-word budget)"]
+        DISC["Discard the forks —<br>nothing accumulates, nothing bleeds"]
+        SUMM["Doku: tree summary on the root<br>(only if anything split)"]
+        REPORT(["exit 0 — script dies<br>human reads briefs, picks leaves to build"])
+    end
+
+    PRIME --> PQ --> NEXT
+    NEXT -- "already converged" --> NEXT
+    NEXT --> TRI
+    TRI -- "split" --> SPLITN --> NEXT
+    TRI -- "reject + concur" --> CLOSED["Issue closed as not planned"] --> NEXT
+    TRI -- "reject + veto" --> DEB
+    TRI -- "proceed / reshape" --> DEB
+    DEB -- "converged" --> BRIEF --> DISC --> NEXT
+    DEB -- "blocked" --> DISC
+    NEXT -- "queue empty" --> SUMM --> REPORT
+
+    subgraph BUILDP["Invocation B — build one converged leaf"]
+        BUILD0["Reuse existing draft PR,<br>or Spectacle opens one<br>(spec + assumptions ledger,<br>written against current master)"]
+        Q["Devin: implement<br>verify assumptions in-file<br>false assumption: stop, comment, stay draft"]
+        R["Devin: one self-review, mark ready"]
+        DR{"PR ready?"}
+        S{"Driver runs make ci"}
+        T["Devin: one repair pass"]
+        U["Reviewer: reads ci log + diff<br>max 3 rounds"]
+        V["Devin: fix or push back"]
+        W["Label: reviewer-approves"]
+        X["Doku: user-facing note"]
+        Y["Cleanup — logs are kept"]
+    end
+
+    BUILD0 --> Q --> R --> DR
+    DR -- "still draft" --> EXIT6(["exit 6 — read devin's PR comment,<br>amend the spec, call again"])
+    DR -- "ready" --> S
+    S -- "fail" --> T --> S
+    S -- "pass" --> U
+    U -- "blockers" --> V
+    V -- "new commit" --> S
+    V -- "pushback only" --> U
+    U -- "nothing blocks" --> W --> X --> Y --> DONE(["exit 0 — PR ready for merge<br>human merges, then calls the next leaf"])
+    U -- "3 rounds spent" --> FAIL3(["exit 3 — not approved"])
+```
+
+**Reading keys**
+
+- **Two invocations by design.** Planning always ends with the script dying after every leaf is briefed — the human reads doku's briefs (and the tree summary on the root) and decides what gets built, while disagreeing is still cheap. Build runs one leaf per call, in the `CHILDREN:` order, with the human merging between calls so each leaf builds on the previous one's merged code.
+- **Labels are the state machine.** No verdict → plan. `owens-split` → its children get planned. Converged → build. Blocked → refused until resolved. Re-calling after a crash lands in the right phase automatically; an existing draft PR is reused, never duplicated.
+- **The primer.** Planning primes one role-neutral session on the repo, then `orchestrator fork`s it per issue and per role; forks are discarded after their leaf. Repo knowledge is shared through the primer; debate content never is.
+- Code is opened during the debate only when a claim is **disputed and decision-changing**, checked by whoever can check cheapest; everything else rides the assumptions ledger to devin, who verifies in the files he is editing anyway. A false assumption stops the build (exit 6) with devin's finding as a PR comment — amend the spec and call again.
+- The driver owns `make ci`; the reviewer reads the log instead of re-running gates. Remote (GitHub-hosted) CI is never consulted — local `make ci` is authoritative.
+- Run-state vs record: `teams/` content dies with each issue's processing (fresh team + worktree per issue, stale ones reset); `logs/issue-N/<timestamp>/` is permanent.
+- Exit codes: 0 phase completed (planning done / rejected / PR approved) · 1 blocked or unconverged · 2 no PR · 3 not approved in 3 rounds · 4 dirty checkout · 5 worktree/branch failure · 6 draft after self-review (false assumption) · 7 CI unfixable · 8 devin didn't commit/push · 9 tree too big or unparseable split.

--- a/examples/gabriels_workflow_v5/go.py
+++ b/examples/gabriels_workflow_v5/go.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""gdw v5. flow.md is the specification, README.md the brief. The issue's
+labels route every call: planning (invocation A) primes one role-neutral
+session, forks it per issue and role, and debates every leaf of the issue
+tree to a decision; build (invocation B) turns one converged leaf into an
+approved PR - devin implements and self-reviews, the driver runs make ci,
+the reviewer reads the log, doku posts the user note."""
+
+import json
+import os
+import re
+import shutil
+import string
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def sh(*cmd):
+    """Run a command, return its stripped stdout, raise on failure."""
+    return subprocess.run(
+        cmd, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def talk(agent, text, *flags):
+    """One agent turn; the transcript appends to the agent's log file."""
+    with open(LOG_DIR / f"{agent}.log", "ab") as log:
+        subprocess.run(
+            [
+                "uv",
+                "run",
+                "orchestrator",
+                "talk",
+                agent,
+                "--team",
+                TEAM,
+                "-v",
+                "--timeout",
+                TIMEOUT,
+                *flags,
+                "-p",
+                text,
+            ],
+            stdout=log,
+            stderr=log,
+            check=True,
+        )
+
+
+def prompt(name, **subs):
+    """Render prompts/<name>.md, substituting only the explicit variable list."""
+    text = (PROMPT_DIR / f"{name}.md").read_text()
+    return string.Template(text).safe_substitute(subs)
+
+
+if len(sys.argv) != 2:
+    sys.exit("usage: python go.py <issue-url>")
+
+ISSUE_URL = sys.argv[1].rstrip("/")
+ISSUE_NUMBER = ISSUE_URL.rsplit("/", 1)[1]
+TEAM = f"issue-{ISSUE_NUMBER}"
+REPO = Path(
+    sh("git", "rev-parse", "--path-format=absolute", "--git-common-dir")
+).parent.name
+TEAMS_DIR = Path.home() / ".agents-army" / REPO / "gdw-v5"
+WORKTREE = TEAMS_DIR / TEAM / "worktree"
+LOG_DIR = TEAMS_DIR / "logs" / f"issue-{ISSUE_NUMBER}" / time.strftime("%Y%m%d-%H%M%S")
+PROMPT_DIR = Path(__file__).resolve().parent / "prompts"
+os.environ["AGENTS_ARMY_TEAMS_DIR"] = str(TEAMS_DIR)
+
+BACKEND = [
+    "-b",
+    "claude",
+    "-m",
+    "opus",
+]  # an agent's first talk carries these, never again
+EFFORT = {"owen": "medium", "spectacle": "low", "doku": "medium"}
+TIMEOUT = "10800"
+PLAN_CAP = 12
+OWEN_VERDICTS = {"owens-is-happy", "owens-rejects", "owens-is-blocked", "owens-split"}
+
+PRIMER_PROMPT = (
+    "You are a primer session: study this repository so that agents forked from "
+    "you start already oriented. Read the README, the docs, and enough of the "
+    "code to know the layout, the main components, the conventions, and how the "
+    "project is tested. Change nothing and write nothing. Reply with a short "
+    "summary of what the project is and how it is put together."
+)
+
+FORKS = set()  # the forks alive for the issue being planned
+FORK_WORKS = True  # flips off if the fork verb refuses at runtime
+CI_RUNS = []  # the driver's own make ci runs: {"head", "log"} each
+
+
+# --- Labels are the state machine -------------------------------------------
+
+
+def issue_labels(url):
+    """Label names, plus the issue's OPEN/CLOSED state riding along as a
+    pseudo-label so one call answers both questions."""
+    info = json.loads(sh("gh", "issue", "view", url, "--json", "labels,state"))
+    return {label["name"] for label in info["labels"]} | {info["state"]}
+
+
+def blocked(labels):
+    return bool(labels & {"owens-is-blocked", "spectacle-is-blocked"})
+
+
+def converged(labels):
+    return labels >= {"owens-is-happy", "spectacle-is-happy"}
+
+
+def num(url):
+    return url.rsplit("/", 1)[1]
+
+
+def fresh_team_and_worktree():
+    """Per issue: a fresh team and a fresh worktree from origin/master; stale
+    leftovers from a dead run are deleted before the first talk."""
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(WORKTREE)], capture_output=True
+    )
+    sh("git", "worktree", "prune")
+    shutil.rmtree(TEAMS_DIR / TEAM, ignore_errors=True)
+    sh("git", "fetch", "origin")
+    if subprocess.run(
+        ["git", "worktree", "add", "--detach", str(WORKTREE), "origin/master"]
+    ).returncode:
+        print(f"Could not create the worktree at {WORKTREE}.", file=sys.stderr)
+        sys.exit(5)
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Issue {ISSUE_NUMBER} in {REPO}. Agent output goes to {LOG_DIR}")
+
+
+def cleanup():  # Y - the team and worktree die with the run; logs are kept
+    print("Cleaning up the team and worktree - logs are kept.")
+    sh("uv", "run", "orchestrator", "delete", "--team", TEAM)
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(WORKTREE)], capture_output=True
+    )
+    shutil.rmtree(TEAMS_DIR / TEAM, ignore_errors=True)
+
+
+# --- Invocation A - planning (recursive, then dies) --------------------------
+
+
+def prime():  # PRIME - one role-neutral session reads the repo, once per run
+    print("Priming: one role-neutral session reads the repo.")
+    talk("primer", PRIMER_PROMPT, *BACKEND, "-e", "medium")
+
+
+def fork_primer(role, url):
+    """TRI, DEB, and BRIEF all begin "fork primer -> <role>". Returns the agent
+    name plus the backend flags its next talk must carry: none for a real fork
+    (it inherits the primer's config - the fork verb has no override), the full
+    role flags when fork is unavailable and fresh agents stand in."""
+    global FORK_WORKS
+    name = f"{role}-{num(url)}"
+    if name in FORKS:
+        return name, []
+    FORKS.add(name)
+    if FORK_WORKS:
+        try:
+            sh("uv", "run", "orchestrator", "fork", "primer", name, "--team", TEAM)
+            return name, []
+        except subprocess.CalledProcessError:
+            FORK_WORKS = False
+            print(
+                "The fork verb is unavailable - falling back to fresh agents per issue."
+            )
+    return name, [*BACKEND, "-e", EFFORT[role]]
+
+
+def triage(url):  # TRI - owen: proceed / reshape / reject / split
+    print(f"Owen: triaging {url} (proceed / reshape / reject / split).")
+    name, flags = fork_primer("owen", url)
+    talk(name, prompt("owen-triage", issue_url=url), *flags)
+    return issue_labels(url)
+
+
+def split_children(url):  # SPLITN - children from the CHILDREN: line, build order
+    bodies = sh(
+        "gh", "issue", "view", url, "--json", "comments", "--jq", ".comments[].body"
+    )
+    lines = [line for line in bodies.splitlines() if line.startswith("CHILDREN:")]
+    numbers = re.findall(r"#(\d+)", lines[-1]) if lines else []
+    if not numbers:
+        print(
+            f"{url} is labeled owens-split but has no parseable CHILDREN: line.",
+            file=sys.stderr,
+        )
+        sys.exit(9)
+    return [url.rsplit("/", 1)[0] + "/" + n for n in numbers]
+
+
+def debate(url, labels):  # DEB - critique / concur-veto -> (rebuttal -> final decision)
+    if "owens-rejects" in labels:
+        print("Owen rejected the idea. Spectacle: one concur/veto turn.")
+        name, flags = fork_primer("spectacle", url)
+        talk(name, prompt("spectacle-reject-review", issue_url=url), *flags)
+        if "CLOSED" in issue_labels(url):
+            return "closed as not planned"  # CLOSED - a decision, not a failure
+        print("Spectacle vetoed the rejection. Owen: write the proposal.")
+        name, flags = fork_primer("owen", url)
+        talk(name, prompt("owen-proposal-after-veto", issue_url=url), *flags)
+    if blocked(issue_labels(url)):
+        return "blocked"
+    print("Spectacle: requirements critique.")
+    name, flags = fork_primer("spectacle", url)
+    talk(name, prompt("spectacle-critique", issue_url=url), *flags)
+    labels = issue_labels(url)
+    if blocked(labels):
+        return "blocked"
+    if not converged(labels):
+        print("Disputed. Owen: one rebuttal.")
+        name, flags = fork_primer("owen", url)
+        talk(name, prompt("owen-rebuttal", issue_url=url), *flags)
+        if blocked(issue_labels(url)):
+            return "blocked"
+        print("Spectacle: final decision.")
+        name, flags = fork_primer("spectacle", url)
+        talk(name, prompt("spectacle-final-decision", issue_url=url), *flags)
+    labels = issue_labels(url)
+    if blocked(labels):
+        return "blocked"
+    return "converged" if converged(labels) else "unconverged"
+
+
+def decision_brief(url):  # BRIEF - doku's 350-word decision brief on the leaf
+    print("Doku: writing the decision brief.")
+    name, flags = fork_primer("doku", url)
+    talk(name, prompt("doku-decision-brief", issue_url=url), *flags)
+
+
+def discard_forks(url):  # DISC - nothing accumulates, nothing bleeds
+    for role in ("owen", "spectacle", "doku"):
+        name = f"{role}-{num(url)}"
+        if name in FORKS:
+            sh("uv", "run", "orchestrator", "delete", name, "--team", TEAM)
+            FORKS.discard(name)
+
+
+def tree_summary():  # SUMM - doku's plan of record on the root, only if anything split
+    print("Doku: tree summary on the root.")
+    name, flags = fork_primer("doku", ISSUE_URL)
+    talk(name, prompt("doku-tree-summary", issue_url=ISSUE_URL), *flags)
+
+
+def plan():  # Invocation A - BFS the tree, debate every leaf, then die
+    fresh_team_and_worktree()
+    prime()
+    queue, taken, split_any = [ISSUE_URL], 0, False  # PQ
+    while queue:  # NEXT
+        url, taken = queue.pop(0), taken + 1
+        if taken > PLAN_CAP:
+            print(
+                f"More than {PLAN_CAP} issues in one run - tree too big.",
+                file=sys.stderr,
+            )
+            sys.exit(9)
+        labels = issue_labels(url)
+        if converged(labels) or "CLOSED" in labels:
+            print(f"{url} needs no planning turn - skipping.")
+            continue
+        if not labels & OWEN_VERDICTS:
+            labels = triage(url)
+        if "owens-split" in labels:
+            children = split_children(url)
+            print(f"{url} split into {len(children)} children, queued in build order.")
+            queue += children
+            split_any = True
+        else:
+            verdict = debate(url, labels)
+            print(f"{url}: {verdict}.")
+            if verdict == "converged":
+                decision_brief(url)
+        discard_forks(url)
+    if split_any:
+        tree_summary()
+    cleanup()
+    print(
+        "Planning done. Read the briefs, pick the leaves to build, and call "
+        "go.py once per leaf, merging between calls."
+    )
+    sys.exit(0)  # REPORT
+
+
+# --- Invocation B - build one converged leaf ---------------------------------
+
+
+def find_draft_pr():
+    """The list endpoint is read-after-write; the caller polls."""
+    prs = json.loads(
+        sh(
+            "gh",
+            "pr",
+            "list",
+            "--draft",
+            "--limit",
+            "50",
+            "--json",
+            "url,body,headRefName",
+        )
+    )
+    hits = [pr for pr in prs if re.search(rf"(#|issues/){ISSUE_NUMBER}\b", pr["body"])]
+    return (hits[0]["url"], hits[0]["headRefName"]) if hits else None
+
+
+def reuse_or_open_draft_pr():  # BUILD0 - never create a second PR when one exists
+    pr = find_draft_pr()
+    if pr:
+        print(f"Reusing the existing draft PR {pr[0]}.")
+    else:
+        print("Spectacle: opening the draft PR.")
+        talk(
+            "spectacle",
+            prompt("spectacle-draft-pr", issue_url=ISSUE_URL),
+            *BACKEND,
+            "-e",
+            "low",
+        )
+        for _ in range(6):
+            if pr := find_draft_pr():
+                break
+            time.sleep(5)
+    if not pr:
+        print(f"No draft PR found for issue {ISSUE_NUMBER}.", file=sys.stderr)
+        sys.exit(2)
+    pr_url, branch = pr
+    print(f"Draft PR {pr_url} on branch {branch}")
+    sh("git", "-C", str(WORKTREE), "fetch", "origin")
+    if subprocess.run(
+        ["git", "-C", str(WORKTREE), "checkout", "-q", "-B", branch, f"origin/{branch}"]
+    ).returncode:
+        print(f"Could not check out {branch} in the worktree.", file=sys.stderr)
+        sys.exit(5)
+    return pr_url, branch
+
+
+def implement(pr_url):  # Q - the PR description is the whole spec
+    print("Devin: implementing the PR description.")
+    talk(
+        "devin",
+        prompt("devin-implement", pr_url=pr_url),
+        *BACKEND,
+        "-e",
+        "low",
+        "-s",
+        "implement,tdd,code-review-and-quality",
+    )
+
+
+def self_review(pr_url):  # R - one self-review, then mark ready
+    print("Devin: one self-review pass.")
+    talk("devin", prompt("devin-self-review", pr_url=pr_url))
+
+
+def require_committed_and_pushed(pr_url):  # exit 8 - never rely on unpushed work
+    dirty = sh("git", "-C", str(WORKTREE), "status", "--porcelain")
+    if dirty:
+        print(f"Devin left uncommitted work in {WORKTREE}:\n{dirty}", file=sys.stderr)
+        sys.exit(8)
+    local = sh("git", "-C", str(WORKTREE), "rev-parse", "HEAD")
+    remote = sh(
+        "gh", "pr", "view", pr_url, "--json", "headRefOid", "--jq", ".headRefOid"
+    )
+    if local != remote:
+        print(
+            f"Devin's HEAD {local} was not pushed to the PR head {remote}.",
+            file=sys.stderr,
+        )
+        sys.exit(8)
+
+
+def run_make_ci():  # S - the driver owns make ci; reviewers read the log
+    ci_log = LOG_DIR / f"ci-{len(CI_RUNS) + 1}.log"
+    ci_head = sh("git", "-C", str(WORKTREE), "rev-parse", "HEAD")
+    CI_RUNS.append({"head": ci_head, "log": ci_log})
+    print(f"Running 'make ci' (run {len(CI_RUNS)}) on {ci_head} - log: {ci_log}")
+    with open(ci_log, "wb") as out:
+        return (
+            subprocess.run(
+                ["make", "-C", str(WORKTREE), "ci"], stdout=out, stderr=out
+            ).returncode
+            == 0
+        )
+
+
+def ci_gate(pr_url):  # S -> fail -> T (one repair) -> S; a second failure is exit 7
+    if run_make_ci():
+        return
+    print("CI failed. Devin: one repair pass.")
+    talk(
+        "devin",
+        prompt("devin-ci-repair", pr_url=pr_url, ci_log=str(CI_RUNS[-1]["log"])),
+    )
+    require_committed_and_pushed(pr_url)
+    if not run_make_ci():
+        print("CI still failing after the repair pass.", file=sys.stderr)
+        sys.exit(7)
+
+
+def reviewer_approves(pr_url):  # W - the label is the verdict, not the review text
+    labels = sh(
+        "gh", "pr", "view", pr_url, "--json", "labels", "--jq", ".labels[].name"
+    )
+    return "reviewer-approves" in labels.splitlines()
+
+
+def review_rounds(pr_url):  # U -> blockers -> V -> (new commit -> S | pushback -> U)
+    flags = [*BACKEND, "-e", "high", "-s", "code-review-and-quality"]
+    for review_round in (1, 2, 3):
+        print(f"Review round {review_round} of 3. Code reviewer: reviewing the diff.")
+        talk(
+            "code-reviewer",
+            prompt(
+                "code-reviewer-review",
+                pr_url=pr_url,
+                ci_head=CI_RUNS[-1]["head"],
+                ci_log=str(CI_RUNS[-1]["log"]),
+            ),
+            *flags,
+        )
+        flags = []
+        if reviewer_approves(pr_url):
+            print("Reviewer approved.")
+            return
+        if review_round == 3:
+            break
+        print("Devin: addressing the review feedback.")
+        old_head = sh("git", "-C", str(WORKTREE), "rev-parse", "HEAD")
+        talk("devin", prompt("devin-review-response", pr_url=pr_url))
+        require_committed_and_pushed(pr_url)
+        if sh("git", "-C", str(WORKTREE), "rev-parse", "HEAD") != old_head:
+            ci_gate(pr_url)  # a pushback without a commit goes straight back to U
+    print("PR not approved after 3 review rounds.", file=sys.stderr)
+    sys.exit(3)  # FAIL3
+
+
+def user_note(pr_url):  # X - doku's user-facing note on the PR
+    print("Doku: writing the user-facing note on the PR.")
+    talk("doku", prompt("doku-user-note", pr_url=pr_url), *BACKEND, "-e", "medium")
+
+
+def build():  # Invocation B - one converged leaf to an approved PR
+    fresh_team_and_worktree()
+    pr_url, branch = reuse_or_open_draft_pr()  # BUILD0
+    implement(pr_url)  # Q
+    self_review(pr_url)  # R
+    if (
+        sh("gh", "pr", "view", pr_url, "--json", "isDraft", "--jq", ".isDraft")
+        != "false"
+    ):
+        print(
+            "PR is still a draft after the self-review - devin found a false "
+            "assumption. Read his PR comment, amend the spec, call again.",
+            file=sys.stderr,
+        )
+        sys.exit(6)  # DR - still draft
+    require_committed_and_pushed(pr_url)
+    ci_gate(pr_url)  # S and T
+    review_rounds(pr_url)  # U and V, approval sets W's label
+    user_note(pr_url)  # X
+    cleanup()  # Y
+    subprocess.run(["git", "branch", "-q", "-D", branch], capture_output=True)
+    print(f"Done. {pr_url} is approved and ready for merge.")
+    sys.exit(0)  # DONE
+
+
+# --- The story, top to bottom ------------------------------------------------
+
+dirty = sh("git", "status", "--porcelain")
+if dirty:
+    print(
+        f"Uncommitted changes in {os.getcwd()} - commit or stash them first:\n{dirty}",
+        file=sys.stderr,
+    )
+    sys.exit(4)
+
+labels = issue_labels(ISSUE_URL)  # ROUTE - the labels decide the invocation
+if blocked(labels):
+    print("The issue is blocked - resolve the missing evidence first.", file=sys.stderr)
+    sys.exit(1)  # RB
+if converged(labels):
+    build()  # Invocation B - build one converged leaf
+plan()  # Invocation A - planning (recursive, then dies)

--- a/examples/gabriels_workflow_v5/prompts/code-reviewer-review.md
+++ b/examples/gabriels_workflow_v5/prompts/code-reviewer-review.md
@@ -1,0 +1,20 @@
+Review PR '$pr_url'. Its description is the complete spec. Review the current
+diff against it and the five quality axes.
+
+The driver has already run 'make ci' successfully on commit '$ci_head'; the
+full log is '$ci_log'. Confirm HEAD matches before relying on it, and do not
+rerun the full gate without concrete evidence that the logged result is
+insufficient.
+
+The description ends with an Assumptions section; the developer was told to
+verify each one in-file. Spot-check that the load-bearing ones actually hold
+in the diff.
+
+Report only re-checkable findings, clearly separating blockers from optional
+observations. Do not change code. If nothing blocks merging, add the label
+'reviewer-approves' to the PR with 'gh pr edit'. Writing the label name into
+your review comment does not set it, and the driver reads the label rather
+than your reply.
+Post as the github app:
+app_id: 4287312
+private_key: ~/keys/ai-specialist-reviewer.2026-08-04.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/devin-ci-repair.md
+++ b/examples/gabriels_workflow_v5/prompts/devin-ci-repair.md
@@ -1,0 +1,4 @@
+The driver ran 'make ci' on '$pr_url' and it failed. Read the complete log at
+'$ci_log'. Fix the actual failure, run focused checks in the foreground,
+commit, and push. Do not broaden scope. Return only after the branch contains
+the fix.

--- a/examples/gabriels_workflow_v5/prompts/devin-implement.md
+++ b/examples/gabriels_workflow_v5/prompts/devin-implement.md
@@ -1,0 +1,15 @@
+Implement the complete description of '$pr_url' as a lead software engineer.
+Do not read the linked issue or its comments - the description is the whole
+spec.
+
+The description ends with an Assumptions section. Verify each assumption as
+you touch its area - you are in those files anyway. If one turns out false,
+do not improvise around it: comment on the PR saying what is false and what
+you recommend, stop, and leave the PR as draft.
+
+Use TDD, keep the design maintainable, and push the implementation to the PR
+branch. Run commands in the foreground and do not return while tests or gates
+are still running. Leave the PR as draft: one separate self-review follows.
+Post as the github app:
+app_id: 4579193
+private_key: ~/keys/devin-development-specialist.2026-08-13.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/devin-review-response.md
+++ b/examples/gabriels_workflow_v5/prompts/devin-review-response.md
@@ -1,0 +1,8 @@
+Read the latest review feedback on '$pr_url'. Address each blocking finding
+exactly once: fix it, or push back with re-checkable code facts. Optional
+findings are your judgment. Reply on the PR explaining the decision. If code
+changes, commit and push them. Finish foreground commands before returning.
+Do not perform a generic self-review.
+Post as the github app:
+app_id: 4579193
+private_key: ~/keys/devin-development-specialist.2026-08-13.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/devin-self-review.md
+++ b/examples/gabriels_workflow_v5/prompts/devin-self-review.md
@@ -1,0 +1,8 @@
+Perform your one final self-review of '$pr_url' across correctness, tests,
+maintainability, security, and scope. Inspect the actual diff with fresh eyes.
+Fix, commit, and push anything you find. Run required commands in the
+foreground.
+
+When the code is something you stand behind, mark the PR ready for review. If
+you stopped over a false assumption, leave the PR as draft - your PR comment
+is what the human reads. This is the only generic self-review turn.

--- a/examples/gabriels_workflow_v5/prompts/doku-decision-brief.md
+++ b/examples/gabriels_workflow_v5/prompts/doku-decision-brief.md
@@ -1,0 +1,21 @@
+Read the issue '$issue_url' and every comment on it, in order. That thread is
+the decision record: the opening request, what the author proposed, what the
+reviewer challenged, and what was settled. No implementation exists yet.
+
+Post one comment on the issue telling a lead developer who does not know this
+codebase what is about to be built and why. Hard budget: 350 words. Write
+about decisions and behaviour, not code - no file paths, no function or class
+names, no snippets.
+
+Cover: the problem, the solution, terms and who is impacted; what was decided;
+where the decision departs from the original request and why, since the
+discussion is allowed to change the ask; and the one or two real risks with
+what catches them. Mention a rejected alternative or an accepted compromise
+only if it was genuinely contested in the thread. One or two sentences per
+point is enough - filler is worse than omission, but every point above gets
+its answer.
+
+Return nothing here, just the comment in short paragraphs or bullets.
+Post as the github app:
+app_id: 4577311
+private_key: ~/keys/doku-documentation-agent.2026-08-12.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/doku-tree-summary.md
+++ b/examples/gabriels_workflow_v5/prompts/doku-tree-summary.md
@@ -1,0 +1,20 @@
+The issue '$issue_url' was split, and every descendant leaf has now been
+debated to a decision. Read this issue and each child issue it references
+(children may have split further - follow the tree to the leaves), including
+the decision brief posted on every converged leaf.
+
+Post one comment on '$issue_url': the plan of record a human reads before
+deciding what gets built. Hard budget: 400 words. Cover:
+
+- The tree: every leaf with its issue number and a one-line what-it-delivers,
+  in build order, with the dependencies between them stated.
+- What the tree as a whole achieves, versus the original ask on this issue.
+- Any leaf that was rejected or is blocked, with its one-line reason.
+- The open assumptions that span leaves - the ones a later build could
+  invalidate - so the reader knows where the plan is still soft.
+
+Decisions and behaviour, not code: no file paths, no function or class names.
+Return nothing here, just the comment.
+Post as the github app:
+app_id: 4577311
+private_key: ~/keys/doku-documentation-agent.2026-08-12.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/doku-user-note.md
+++ b/examples/gabriels_workflow_v5/prompts/doku-user-note.md
@@ -1,0 +1,20 @@
+You are the documentation writer for the PR '$pr_url'. Read its description
+and its diff, and read README.md and docs/ to see how the project describes
+itself today.
+
+Post one comment on the PR telling a user of this project what this version
+changes for them. Write plain, non-technical English: short sentences, no
+jargon, no file paths, no internal design talk. Cover what is new or
+different, how to use it with a copy-pasteable command and a real example,
+what they must change on their side to keep working - renamed flags, new
+defaults, removed behaviour - and anything else that would surprise them.
+
+Every claim comes from the diff. Do not describe behaviour you did not see in
+the code, and if the change is invisible to users say so in one line instead
+of inventing detail.
+
+Change no files, review nothing, approve nothing - the comment is the whole
+deliverable.
+Post as the github app:
+app_id: 4577311
+private_key: ~/keys/doku-documentation-agent.2026-08-12.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/owen-proposal-after-veto.md
+++ b/examples/gabriels_workflow_v5/prompts/owen-proposal-after-veto.md
@@ -1,0 +1,13 @@
+The reviewer vetoed your rejection of '$issue_url'. Read the veto; it is
+final - the idea gets a proposal.
+
+Post one compact proposal in the issue: the behavior to change, the affected
+areas, the acceptance criteria, and every unproven claim explicitly marked as
+an assumption. Reshape the ask if the veto pointed at a better outcome - your
+job is a good outcome for the project, not a surviving position. Do not
+enumerate alternatives and do not restate the issue.
+
+Then add the label 'owens-is-happy' with 'gh issue edit', or 'owens-is-blocked'
+only when missing external evidence prevents a decision. Naming a label in a
+comment does not set it.
+Post in the issue; return only a short status here.

--- a/examples/gabriels_workflow_v5/prompts/owen-rebuttal.md
+++ b/examples/gabriels_workflow_v5/prompts/owen-rebuttal.md
@@ -1,0 +1,14 @@
+This is your only rebuttal on '$issue_url'. Read the reviewer's blocking
+disagreements.
+
+Answer only those points and state your final position. Each dispute comes
+with the reviewer's named settling check: run it and let the result decide -
+concede or stand on the output, not on more argument. If a check is cheaper
+still at implementation time, move it to the assumptions list instead of
+running it here. Add no optional scope and no new alternatives.
+
+Add the label 'owens-is-happy' if the reviewer can now make the final
+implementation decision, or 'owens-is-blocked' only if external evidence is
+genuinely missing. Set it with 'gh issue edit'; naming a label in a comment
+does not set it.
+Post in the issue; return only a short status here.

--- a/examples/gabriels_workflow_v5/prompts/owen-triage.md
+++ b/examples/gabriels_workflow_v5/prompts/owen-triage.md
@@ -1,0 +1,38 @@
+Look at issue '$issue_url' as its Issue Author and product owner. There is no
+human in the loop; the decisions are yours.
+
+Read the ask and do a bounded recon of the code: just enough to name the
+affected areas and judge the size. Do not verify every claim - anything you
+did not check is an assumption, and you will mark it as one.
+
+The original ask can be a bad idea, be too big, or be smaller than what the
+project actually needs. Judge it and take exactly one of these four paths:
+
+1. REJECT - the idea would not leave the project better. Post a comment saying
+   why in plain requirement terms, then add the label 'owens-rejects'.
+2. SPLIT - too big. The sizing bar: one PR a developer can land and a reviewer
+   can genuinely read in one sitting; if the acceptance criteria do not fit a
+   short list, split. Open self-contained child issues with 'gh issue create',
+   each a complete ask on its own that references this issue. Post a comment
+   explaining the split and listing the children in build order, and end that
+   comment with exactly one line of the form 'CHILDREN: #12 #13' naming the
+   child issue numbers in that order - the driver parses it. Then add the
+   label 'owens-split'.
+3. RESHAPE - the underlying need is real but the ask is wrong or too small.
+   Your job is a good outcome for the project, not a surviving proposal - the
+   scope may grow beyond the original ask. Continue as path 4 with your
+   reshaped version.
+4. PROCEED - post one compact proposal in the issue: the behavior to change,
+   the affected areas, the acceptance criteria, and every unproven claim
+   explicitly marked as an assumption. Do not enumerate alternatives and do
+   not restate the issue. Then add the label 'owens-is-happy'.
+
+Add the label 'owens-is-blocked' only when missing external evidence prevents
+any decision at all.
+
+A label is set with 'gh issue edit', not by naming it in a comment; create the
+label first with 'gh label create' if the repo does not have it.
+All communication goes in the GitHub issue; return only a short status here.
+Post as the github app:
+app_id: 4578638
+private_key: ~/keys/owen-project-owner.2026-08-13.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/spectacle-critique.md
+++ b/examples/gabriels_workflow_v5/prompts/spectacle-critique.md
@@ -1,0 +1,31 @@
+Review issue '$issue_url' as the final Issue Reviewer. This turn must produce
+content: a requirements critique of the author's proposal. You may not approve
+silently - an approval without a posted critique is worthless.
+
+Critique at the requirements level, without diving into the code:
+- Does the proposal solve the underlying need of the ask?
+- Is the scope right - not too narrow, not gold-plated?
+- Are the acceptance criteria testable?
+- Which of the listed assumptions are load-bearing?
+
+Open the code only for a claim that you dispute AND whose answer would change
+the decision. Route each check to wherever correctness is cheapest: if one
+cheap command from where you already are settles it, run it yourself and post
+the finding, not the question. If it is not cheap from here, post the dispute
+and name the exact check that settles it, for the author to run in the
+rebuttal - a dispute without a named settling check is an opinion; do not
+post it. Anything cheapest to verify at implementation time stays an
+assumption; the developer verifies assumptions in the files he is editing
+anyway.
+
+If nothing decision-changing is disputed, post the critique showing what you
+checked and add the label 'spectacle-is-happy' in the same turn. Otherwise
+post at most three blocking disagreements, each stating why it changes the
+decision. If you propose an alternative, propose exactly one - no menus of
+options. You get one final decision turn after the author's rebuttal.
+
+Set labels with 'gh issue edit'; naming one in a comment does not set it.
+Post in the issue; return only a short status here.
+Authenticate as the github app:
+app_id: 4287312
+private_key: ~/keys/ai-specialist-reviewer.2026-08-04.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/spectacle-draft-pr.md
+++ b/examples/gabriels_workflow_v5/prompts/spectacle-draft-pr.md
@@ -1,0 +1,17 @@
+The issue '$issue_url' has converged. Open a draft PR against the default
+branch with an empty commit and no file changes. Its description is the
+complete developer handoff. Keep it concise: decided behavior, affected areas,
+acceptance criteria, verification, and evidence only for non-obvious
+load-bearing decisions.
+
+End the description with an 'Assumptions' section: every claim the debate left
+unverified, each phrased so the developer can check it in the code while
+implementing. State there that if an assumption turns out false, the developer
+stops and comments on the PR instead of improvising around it.
+
+Do not reproduce the debate or rejected alternatives unless omitting one would
+cause a likely implementation mistake. Resolve any remaining ambiguity
+yourself. Link the issue.
+Post as the github app:
+app_id: 4287312
+private_key: ~/keys/ai-specialist-reviewer.2026-08-04.private-key.pem

--- a/examples/gabriels_workflow_v5/prompts/spectacle-final-decision.md
+++ b/examples/gabriels_workflow_v5/prompts/spectacle-final-decision.md
@@ -1,0 +1,10 @@
+Make the final decision on '$issue_url'. Read the author's rebuttal and
+resolve every remaining point from the available evidence. Ask no further
+questions and offer no options. Anything still unproven but not
+decision-changing becomes an assumption for the developer to verify, not a
+reason to keep debating.
+
+Add the label 'spectacle-is-happy' to the issue if there is now one
+implementable outcome; otherwise add the label 'spectacle-is-blocked'. Set it
+with 'gh issue edit'; naming a label in a comment does not set it.
+Post the concise decision in the issue and return only a short status here.

--- a/examples/gabriels_workflow_v5/prompts/spectacle-reject-review.md
+++ b/examples/gabriels_workflow_v5/prompts/spectacle-reject-review.md
@@ -1,0 +1,17 @@
+The Issue Author rejected issue '$issue_url' (label 'owens-rejects'). You are
+the Issue Reviewer. A rejection is a load-bearing decision and gets exactly
+one challenge - this turn.
+
+Judge the rejection at the requirements level: does the rationale hold against
+what the ask actually needs? Do not dive into the code.
+
+- If you concur: post a short concurrence and close the issue as not planned
+  with 'gh issue close' and reason "not planned".
+- If you veto: post why the idea deserves a proposal after all, in requirement
+  terms, remove the label 'owens-rejects' with 'gh issue edit --remove-label',
+  and leave the issue open.
+
+Post in the issue; return only a short status here.
+Authenticate as the github app:
+app_id: 4287312
+private_key: ~/keys/ai-specialist-reviewer.2026-08-04.private-key.pem


### PR DESCRIPTION
## What this is

The specification for workflow v5, to be implemented by an agent from these files alone:

- **examples/gabriels_workflow_v5/flow.md** — the diagram. It is the spec: two invocations (recursive planning that dies after every leaf is briefed; stateless per-leaf builds), labels as the state machine, and a primer session forked per issue and role via the orchestrator's new `fork` verb (#130).
- **examples/gabriels_workflow_v5/README.md** — the implementation brief: implement the diagram, exactly, as one Python file `go.py`, plus the operational contracts carried from v4 and the binding coding rules (three ≤8-line helpers, plain data, functions per diagram box, exceptions as the error model; no classes with behavior, no async, no frameworks).
- **examples/gabriels_workflow_v5/prompts/** — the 15 agent-turn prompts, final versions (CHILDREN: line on splits, checks routed to the cheapest verifier, 350/400-word doku budgets).

## Instruction to the implementing agent

Implement the diagram in flow.md as `examples/gabriels_workflow_v5/go.py`, following README.md to the letter — the diagram defines every node, edge, and exit code; the README defines the contracts and the coding rules. Where anything disagrees, the diagram wins. Definition of done is in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)