### PR TITLE
Prime on the first fork that needs it, not up front

### DIFF
--- a/examples/gabriels_workflow_v5/README.md
+++ b/examples/gabriels_workflow_v5/README.md
@@ -21,9 +21,13 @@ by the issue's labels — the router at the top of the diagram:
   devin implements and self-reviews, the driver runs `make ci` itself, at most
   three review rounds, doku's user note, cleanup.
 
-The primer: planning starts by creating one role-neutral agent whose only turn
-is to study the repository, then uses `uv run orchestrator fork <src> <dst>`
-to give each issue's owen, spectacle, and doku a fresh fork of that session.
+The primer: the first fork that needs one creates a role-neutral agent whose
+only turn is to study the repository, then uses `uv run orchestrator fork <src>
+<dst>` to give each issue's owen, spectacle, and doku a fresh fork of that
+session. Priming is lazy rather than up front because a split parent never
+converges: re-running one routes to planning even when every child is already
+groomed, and the walk then skips them all — priming first would buy a full repo
+read that nothing forks from.
 Forks are deleted after their issue. The fork verb exists in this repository —
 read its docs and `--help` before use. If fork is unavailable at runtime, fall
 back to fresh agents per issue and print that the fallback is in effect. A role

--- a/examples/gabriels_workflow_v5/flow.md
+++ b/examples/gabriels_workflow_v5/flow.md
@@ -10,11 +10,11 @@ flowchart TD
     START(["go.py + issue URL"]) --> ROUTE{"Labels?"}
     ROUTE -- "blocked" --> RB(["exit 1 — resolve evidence first"])
     ROUTE -- "owens-is-happy +<br>spectacle-is-happy" --> BUILD0
-    ROUTE -- "anything else" --> PRIME
+    ROUTE -- "anything else" --> PQ
 
     subgraph PLAN["Invocation A — planning (recursive, then dies)"]
-        PRIME["Prime once per run:<br>one role-neutral session reads the repo"]
         PQ["Queue = [issue]<br>cap: 12 issues per run"]
+        PRIME["Prime, on the first fork that needs it:<br>one role-neutral session reads the repo, once per run<br>(never runs if every issue is already converged)"]
         NEXT{"Next issue<br>from queue"}
         TRI["fork primer → owen: triage<br>(proceed / reshape / reject / split)"]
         SPLITN["Children from the CHILDREN: line<br>queued in build order<br>(their forks share the same primer)"]
@@ -25,9 +25,9 @@ flowchart TD
         REPORT(["exit 0 — script dies<br>human reads briefs, picks leaves to build"])
     end
 
-    PRIME --> PQ --> NEXT
+    PQ --> NEXT
     NEXT -- "already converged" --> NEXT
-    NEXT --> TRI
+    NEXT --> PRIME --> TRI
     TRI -- "split" --> SPLITN --> NEXT
     TRI -- "reject + concur" --> CLOSED["Issue closed as not planned"] --> NEXT
     TRI -- "reject + veto" --> DEB
@@ -74,7 +74,7 @@ flowchart TD
 
 - **Two invocations by design.** Planning always ends with the script dying after every leaf is briefed — the human reads doku's briefs (and the tree summary on the root) and decides what gets built, while disagreeing is still cheap. Build runs one leaf per call, in the `CHILDREN:` order, with the human merging between calls so each leaf builds on the previous one's merged code.
 - **Labels are the state machine.** No verdict → plan. `owens-split` → its children get planned. Converged → build. Blocked → refused until resolved. Re-calling after a crash lands in the right phase automatically; an existing draft PR is reused, never duplicated.
-- **The primer.** Planning primes one role-neutral session on the repo, then `orchestrator fork`s it per issue and per role; forks are discarded after their leaf. Repo knowledge is shared through the primer; debate content never is.
+- **The primer.** The first fork that needs it primes one role-neutral session on the repo, then `orchestrator fork`s it per issue and per role; priming is lazy because a split parent never converges, so re-running one routes to planning even when every child is already groomed — priming up front would buy a repo read that nothing forks from; forks are discarded after their leaf. Repo knowledge is shared through the primer; debate content never is.
 - Code is opened during the debate only when a claim is **disputed and decision-changing**, checked by whoever can check cheapest; everything else rides the assumptions ledger to devin, who verifies in the files he is editing anyway. A false assumption stops the build (exit 6) with devin's finding as a PR comment — amend the spec and call again.
 - The driver owns `make ci`; the reviewer reads the log instead of re-running gates. Remote (GitHub-hosted) CI is never consulted — local `make ci` is authoritative *because the stale-base gate guarantees it ran on a branch containing current `origin/master`*. Parallel runs take turns on a machine-wide CI lock, so gates never fight for cores.
 - **Parallel runs.** Each issue works in a private full clone (at `<team>/worktree` — the path `--team` resolves as the workdir), so concurrent runs share no git state; a per-issue flock refuses a second run on the same issue (exit 4). Parallelize across *independent* issues only: the leaves of one split tree still build serially in `CHILDREN:` order — siblings edit the same files, and every merge forces every other in-flight branch through a re-gate.

--- a/examples/gabriels_workflow_v5/go.py
+++ b/examples/gabriels_workflow_v5/go.py
@@ -122,6 +122,7 @@ PRIMER_PROMPT = (
 )
 
 FORKS = set()  # the forks alive for the issue being planned
+PRIMED = False  # the primer is read once per run, on the first fork that needs it
 FORK_WORKS = True  # flips off if the fork verb refuses at runtime
 CI_RUNS = []  # the driver's own make ci runs: {"head", "log"} each
 
@@ -174,8 +175,16 @@ def cleanup():  # Y - the team and clone die with the run; logs are kept
 
 
 def prime():  # PRIME - one role-neutral session reads the repo, once per run
+    """Called from the first fork that will actually use it, not up front: a
+    split parent is never converged, so re-running it routes to planning, and
+    if every child is already groomed the walk skips them all. Priming before
+    that walk would buy a full repo read that nothing forks from."""
+    global PRIMED
+    if PRIMED:
+        return
     print(f"Priming: one role-neutral session reads the repo. {conf(PRIMER)}")
     talk("primer", PRIMER_PROMPT, *flags_for(PRIMER))
+    PRIMED = True
 
 
 def fork_primer(role, url):
@@ -194,6 +203,7 @@ def fork_primer(role, url):
         return name, []
     FORKS.add(name)
     if FORK_WORKS and ROLES[role]["backend"] == PRIMER["backend"]:
+        prime()  # outside the try - a failed primer turn is not a refused fork
         try:
             sh("uv", "run", "orchestrator", "fork", "primer", name, "--team", TEAM)
             print(f"  {name} forks the primer, inheriting {conf(PRIMER)}")
@@ -284,7 +294,6 @@ def tree_summary():  # SUMM - doku's plan of record on the root, only if anythin
 
 def plan():  # Invocation A - BFS the tree, debate every leaf, then die
     fresh_team_and_clone()
-    prime()
     queue, taken, split_any = [ISSUE_URL], 0, False  # PQ
     while queue:  # NEXT
         url, taken = queue.pop(0), taken + 1


### PR DESCRIPTION
## Change

`prime()` no longer runs at the top of `plan()`. It runs from the first
`fork_primer()` that will actually use it, guarded by a `PRIMED` flag so it
still happens at most once per run.

## Why

A split parent never converges, so re-running one routes to planning even when
every child is already groomed. The walk then skips all of them, and the up-front
priming turn buys a full repo read that nothing forks from.

The `prime()` call sits outside the `try` in `fork_primer()` on purpose: a failed
primer turn is a failed run, not a refused fork falling back to a fresh agent.

## Scope

`go.py`, plus `flow.md` and `README.md` kept in sync with it — the diagram now
routes `PQ -> NEXT -> PRIME -> TRI` instead of priming ahead of the queue.
No production module is touched.
